### PR TITLE
Fix auto-pause with non-AAC Bluetooth codecs

### DIFF
--- a/src/lib/devices/mediaController.js
+++ b/src/lib/devices/mediaController.js
@@ -136,7 +136,11 @@ export const MediaController = GObject.registerClass({
             if (!noSymbolName.includes(this._noSymbolMac))
                 continue;
             const device = this._control.lookup_device_from_stream(sink);
-            if (device?.get_active_profile() === 'a2dp-sink')
+            // PipeWire names the A2DP sink profile per negotiated codec, e.g.
+            // 'a2dp-sink' (AAC), 'a2dp-sink-sbc', 'a2dp-sink-sbc_xq',
+            // 'a2dp-sink-aptx', 'a2dp-sink-ldac'. Match the family prefix so
+            // playback control works regardless of the active codec.
+            if (device?.get_active_profile()?.startsWith('a2dp-sink'))
                 return sink;
         }
         return null;


### PR DESCRIPTION
Hey! So auto-pause wasn't working for me on my AirPods Pro 2 — ear
detection itself was fine (battery and noise control updated whenever I
pulled a bud out), music just never paused.

Dug into it a bit. `_findA2dpSinkForMac()` looks for the profile named
exactly `a2dp-sink`, but that name's only used for AAC — other codecs
get a suffix like `a2dp-sink-sbc_xq`. Mine's on SBC-XQ, so the lookup
came back empty, `_sink` stayed null, and `changeActivePlayerState()`
just returned early without doing anything.

Switched it to match the `a2dp-sink` prefix and that did it. Tested on
Fedora + KDE Wayland, working great now. Thanks for the app, btw!