### PR TITLE
Add Swiss German (de_CH) translation

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -11,6 +11,7 @@ ckb
 cs
 da
 de
+de_CH
 el
 en_GB
 eo

--- a/po/de_CH.po
+++ b/po/de_CH.po
@@ -1,0 +1,1286 @@
+# Swiss German translations for BudsLink package.
+# Copyright (C) 2026 maniacx@github.com
+# This file is distributed under the same license as the BudsLink package.
+# Samuel Rüegger <samuel@rueegger.me>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: BudsLink\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-08 21:44-0600\n"
+"PO-Revision-Date: 2026-05-16 12:00+0200\n"
+"Last-Translator: Samuel Rüegger <samuel@rueegger.me>\n"
+"Language-Team: Swiss German\n"
+"Language: de_CH\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: src/app.js:180 src/appLibs/widgets/deviceRow.js:59
+msgid "BudsLink"
+msgstr "BudsLink"
+
+#: src/app.js:190
+msgid "Devices"
+msgstr "Geräte"
+
+#: src/app.js:192
+msgid "No compatible device found"
+msgstr "Kein kompatibles Gerät gefunden"
+
+#: src/appLibs/widgets/settingsButton.js:22
+msgid "Application Settings"
+msgstr "Anwendungseinstellungen"
+
+#: src/appLibs/widgets/settingsButton.js:31
+#: src/appLibs/widgets/settingsButton.js:178
+msgid "System Default"
+msgstr "Systemstandard"
+
+#: src/appLibs/widgets/settingsButton.js:32
+msgid "Blue"
+msgstr "Blau"
+
+#: src/appLibs/widgets/settingsButton.js:33
+msgid "Teal"
+msgstr "Türkis"
+
+#: src/appLibs/widgets/settingsButton.js:34
+msgid "Green"
+msgstr "Grün"
+
+#: src/appLibs/widgets/settingsButton.js:35
+msgid "Yellow"
+msgstr "Gelb"
+
+#: src/appLibs/widgets/settingsButton.js:36
+msgid "Orange"
+msgstr "Orange"
+
+#: src/appLibs/widgets/settingsButton.js:37
+msgid "Red"
+msgstr "Rot"
+
+#: src/appLibs/widgets/settingsButton.js:38
+msgid "Pink"
+msgstr "Rosa"
+
+#: src/appLibs/widgets/settingsButton.js:39
+msgid "Purple"
+msgstr "Violett"
+
+#: src/appLibs/widgets/settingsButton.js:40
+msgid "Slate"
+msgstr "Schiefer"
+
+#: src/appLibs/widgets/settingsButton.js:61
+msgid "Dark Mode"
+msgstr "Dunkler Modus"
+
+#: src/appLibs/widgets/settingsButton.js:68
+msgid "Accent Color"
+msgstr "Akzentfarbe"
+
+#: src/appLibs/widgets/settingsButton.js:75
+msgid "About BudsLink"
+msgstr "Über BudsLink"
+
+#: src/appLibs/widgets/settingsButton.js:86
+msgid "Copyright © 2026 maniacx@github.com"
+msgstr "Copyright © 2026 maniacx@github.com"
+
+#: src/appLibs/widgets/settingsButton.js:90
+msgid "Translation"
+msgstr "Übersetzung"
+
+#: src/appLibs/widgets/settingsButton.js:101
+msgid "Packet Logging"
+msgstr "Paket-Protokollierung"
+
+#: src/appLibs/widgets/settingsButton.js:179
+msgid "Light"
+msgstr "Hell"
+
+#: src/appLibs/widgets/settingsButton.js:180
+msgid "Dark"
+msgstr "Dunkel"
+
+#: src/appLibs/widgets/settingsButton.js:296
+#: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:678
+#: src/lib/devices/sony/sonyDevice.js:197
+#: src/lib/devices/airpods/airpodsDevice.js:240
+msgid "On"
+msgstr "An"
+
+#: src/appLibs/widgets/settingsButton.js:297
+#: src/preferences/devices/nothingBuds/configureWindow.js:411
+#: src/preferences/devices/galaxyBuds/configureWindow.js:271
+#: src/preferences/devices/galaxyBuds/configureWindow.js:523
+#: src/preferences/devices/sony/configureWindow.js:131
+#: src/preferences/devices/sony/configureWindow.js:215
+#: src/preferences/devices/sony/configureWindow.js:285
+#: src/preferences/devices/sony/configureWindow.js:362
+#: src/preferences/devices/airpods/configureWindow.js:226
+#: src/lib/devices/nothingBuds/nothingBudsDevice.js:371
+#: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:614
+#: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:680
+#: src/lib/devices/sony/sonyDevice.js:166
+#: src/lib/devices/sony/sonyDevice.js:199
+#: src/lib/devices/airpods/airpodsDevice.js:200
+#: src/lib/devices/airpods/airpodsDevice.js:242
+msgid "Off"
+msgstr "Aus"
+
+#: src/appLibs/widgets/deviceRow.js:101
+msgid "Configure"
+msgstr "Einrichten"
+
+#: src/appLibs/widgets/deviceRow.js:113
+msgid "Battery Level"
+msgstr "Akkustand"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:110
+#: src/preferences/devices/galaxyBuds/configureWindow.js:91
+#: src/preferences/devices/sony/configureWindow.js:89
+#: src/preferences/devices/airpods/configureWindow.js:86
+msgid "Icon"
+msgstr "Symbol"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:111
+#: src/preferences/devices/galaxyBuds/configureWindow.js:92
+#: src/preferences/devices/sony/configureWindow.js:90
+#: src/preferences/devices/airpods/configureWindow.js:87
+msgid "Select Icon"
+msgstr "Symbol auswählen"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:112
+#: src/preferences/devices/galaxyBuds/configureWindow.js:93
+#: src/preferences/devices/sony/configureWindow.js:91
+#: src/preferences/devices/airpods/configureWindow.js:88
+msgid "Select the icon used for the indicator and quick menu"
+msgstr "Symbol für Anzeige und Schnellmenü auswählen"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:212
+#: src/preferences/devices/galaxyBuds/configureWindow.js:267
+#: src/preferences/devices/sony/configureWindow.js:212
+msgid "Equalizer"
+msgstr "Equalizer"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:218
+msgid "Balanced"
+msgstr "Ausgewogen"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:219
+msgid "Voice"
+msgstr "Stimme"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:220
+msgid "More Treble"
+msgstr "Mehr Höhen"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:221
+msgid "More Bass"
+msgstr "Mehr Bass"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:222
+msgid "Dirac"
+msgstr "Dirac"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:223
+msgid "Rock"
+msgstr "Rock"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:224
+msgid "Electronic"
+msgstr "Elektronisch"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:225
+msgid "Pop"
+msgstr "Pop"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:226
+msgid "Enhance Vocals"
+msgstr "Stimmen verstärken"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:227
+msgid "Classical"
+msgstr "Klassik"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:228
+msgid "Custom"
+msgstr "Benutzerdefiniert"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:238
+#: src/preferences/devices/nothingBuds/configureWindow.js:670
+#: src/preferences/devices/galaxyBuds/configureWindow.js:290
+#: src/preferences/devices/sony/configureWindow.js:245
+msgid "Equalizer Preset"
+msgstr "Equalizer-Voreinstellung"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:255
+#: src/preferences/devices/sony/configureWindow.js:258
+msgid "Custom Equalizer"
+msgstr "Benutzerdefinierter Equalizer"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:258
+#: src/preferences/devices/nothingBuds/configureWindow.js:676
+#: src/preferences/devices/sony/configureWindow.js:260
+msgid "Bass"
+msgstr "Bass"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:258
+#: src/lib/devices/nothingBuds/nothingBudsDevice.js:395
+msgid "Mid"
+msgstr "Mitten"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:258
+#: src/preferences/devices/nothingBuds/configureWindow.js:679
+msgid "Treble"
+msgstr "Höhen"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:288
+msgid "Bass Enhance"
+msgstr "Bass-Verstärkung"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:291
+msgid "Enable Bass Enhance"
+msgstr "Bass-Verstärkung aktivieren"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:303
+msgid "Bass Enhance Level"
+msgstr "Stufe der Bass-Verstärkung"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:306
+msgid "-"
+msgstr "-"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:310
+msgid "+"
+msgstr "+"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:338
+#: src/preferences/devices/nothingBuds/configureWindow.js:664
+msgid "Spatial Audio"
+msgstr "Räumliches Audio"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:341
+msgid "Enable Spatial Audio"
+msgstr "Räumliches Audio aktivieren"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:358
+#: src/preferences/devices/galaxyBuds/configureWindow.js:613
+msgid "Additional Settings"
+msgstr "Zusätzliche Einstellungen"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:363
+msgid "Enable low latency mode"
+msgstr "Modus mit niedriger Latenz aktivieren"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:376
+msgid "Enable in ear detection"
+msgstr "Trageerkennung aktivieren"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:412
+#: src/preferences/devices/galaxyBuds/configureWindow.js:524
+#: src/preferences/devices/sony/configureWindow.js:361
+#: src/lib/devices/sony/sonyDevice.js:168
+msgid "Ambient"
+msgstr "Umgebung"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:413
+#: src/preferences/devices/galaxyBuds/configureWindow.js:525
+#: src/preferences/devices/sony/configureWindow.js:360
+#: src/preferences/devices/airpods/configureWindow.js:239
+#: src/lib/devices/nothingBuds/nothingBudsDevice.js:419
+#: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:617
+#: src/lib/devices/sony/sonyDevice.js:171
+#: src/lib/devices/airpods/airpodsDevice.js:203
+msgid "Noise Cancellation"
+msgstr "Geräuschunterdrückung"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:422
+msgid "Noise Control Cycle: "
+msgstr "Geräuschsteuerungs-Zyklus: "
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:424
+#: src/preferences/devices/galaxyBuds/configureWindow.js:573
+#: src/preferences/devices/galaxyBuds/configureWindow.js:595
+#: src/preferences/devices/sony/configureWindow.js:369
+#: src/preferences/devices/airpods/configureWindow.js:261
+msgid "Apply"
+msgstr "Anwenden"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:444
+#: src/preferences/devices/galaxyBuds/configureWindow.js:353
+msgid "Single Tap"
+msgstr "Einfaches Tippen"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:445
+#: src/preferences/devices/galaxyBuds/configureWindow.js:366
+msgid "Double Tap"
+msgstr "Doppeltippen"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:446
+#: src/preferences/devices/galaxyBuds/configureWindow.js:379
+msgid "Triple Tap"
+msgstr "Dreifachtippen"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:447
+msgid "Tap and Hold"
+msgstr "Tippen und Halten"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:448
+msgid "Double Tap and Hold"
+msgstr "Doppeltippen und Halten"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:450
+#: src/preferences/devices/nothingBuds/configureWindow.js:465
+msgid "Single Press"
+msgstr "Einfacher Tastendruck"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:451
+#: src/preferences/devices/nothingBuds/configureWindow.js:466
+msgid "Double Press"
+msgstr "Doppelter Tastendruck"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:452
+#: src/preferences/devices/nothingBuds/configureWindow.js:467
+msgid "Triple Press"
+msgstr "Dreifacher Tastendruck"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:453
+#: src/preferences/devices/nothingBuds/configureWindow.js:462
+#: src/preferences/devices/nothingBuds/configureWindow.js:468
+msgid "Press and Hold"
+msgstr "Drücken und Halten"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:454
+#: src/preferences/devices/nothingBuds/configureWindow.js:469
+msgid "Double Press and Hold"
+msgstr "Doppelt drücken und Halten"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:456
+msgid "Single Pinch"
+msgstr "Einfaches Drücken"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:457
+msgid "Double Pinch"
+msgstr "Doppeltes Drücken"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:458
+msgid "Triple Pinch"
+msgstr "Dreifaches Drücken"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:459
+msgid "Pinch and Hold"
+msgstr "Drücken und Halten (Stiel)"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:460
+msgid "Double Pinch and Hold"
+msgstr "Doppeltes Drücken und Halten (Stiel)"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:463
+msgid "Slide to Adjust"
+msgstr "Wischen zum Anpassen"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:470
+msgid "Rotate"
+msgstr "Drehen"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:493
+msgid "Unknown Gesture"
+msgstr "Unbekannte Geste"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:600
+#: src/preferences/devices/nothingBuds/configureWindow.js:618
+msgid "Gesture Controls"
+msgstr "Gestensteuerung"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:603
+msgid "Left Buds Gesture Control"
+msgstr "Gestensteuerung linker Ohrhörer"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:606
+msgid "Right Buds Gesture Control"
+msgstr "Gestensteuerung rechter Ohrhörer"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:609
+msgid "Roller Gesture Control"
+msgstr "Gestensteuerung Roller"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:612
+msgid "Case Gesture Control"
+msgstr "Gestensteuerung Ladecase"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:615
+msgid "Slider Gesture Control"
+msgstr "Gestensteuerung Slider"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:625
+msgid "Play / Pause"
+msgstr "Wiedergabe / Pause"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:628
+msgid "Previous Track"
+msgstr "Vorheriger Titel"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:631
+msgid "Next Track"
+msgstr "Nächster Titel"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:634
+#: src/preferences/devices/galaxyBuds/configureWindow.js:462
+msgid "Voice Assistant"
+msgstr "Sprachassistent"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:637
+msgid "Volume Up"
+msgstr "Lautstärke erhöhen"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:640
+msgid "Volume Down"
+msgstr "Lautstärke verringern"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:643
+#: src/preferences/devices/galaxyBuds/configureWindow.js:464
+#: src/preferences/devices/sony/configureWindow.js:307
+#: src/preferences/devices/airpods/configureWindow.js:312
+msgid "Volume Control"
+msgstr "Lautstärkeregelung"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:646
+#: src/preferences/devices/galaxyBuds/configureWindow.js:467
+#: src/lib/devices/nothingBuds/nothingBudsDevice.js:361
+#: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:579
+#: src/lib/devices/sony/sonyDevice.js:164
+#: src/lib/devices/airpods/airpodsDevice.js:173
+msgid "Noise Control"
+msgstr "Geräuschsteuerung"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:649
+msgid "ANC Type"
+msgstr "ANC-Typ"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:652
+msgid "No Action"
+msgstr "Keine Aktion"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:655
+msgid "Change Volume"
+msgstr "Lautstärke ändern"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:658
+msgid "Channel Hop"
+msgstr "Kanalwechsel"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:661
+msgid "New Reporter"
+msgstr "News-Reporter"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:667
+msgid "Mic On/Off"
+msgstr "Mikrofon ein/aus"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:673
+msgid "Walkie Takie"
+msgstr "Walkie-Talkie"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:682
+msgid "Toggle Low Latency"
+msgstr "Niedrige Latenz umschalten"
+
+#: src/preferences/devices/nothingBuds/configureWindow.js:685
+msgid "Essential Space"
+msgstr "Essential Space"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:115
+#: src/preferences/devices/airpods/configureWindow.js:109
+msgid "Playback Behavior"
+msgstr "Wiedergabeverhalten"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:119
+#: src/preferences/devices/airpods/configureWindow.js:113
+#: src/preferences/devices/airpods/configureWindow.js:116
+msgid "Default behavior"
+msgstr "Standardverhalten"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:120
+#: src/preferences/devices/airpods/configureWindow.js:117
+msgid "Resume with both earbuds, Pause if any removed"
+msgstr "Fortsetzen mit beiden Ohrhörern, pausieren bei Herausnehmen eines Ohrhörers"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:121
+#: src/preferences/devices/airpods/configureWindow.js:118
+msgid "Resume with any earbud, Pause if both removed"
+msgstr "Fortsetzen mit beliebigem Ohrhörer, pausieren bei Herausnehmen beider Ohrhörer"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:125
+#: src/preferences/devices/airpods/configureWindow.js:122
+msgid "Choose playback behaviour for Ear detection"
+msgstr "Wiedergabeverhalten für Trageerkennung wählen"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:126
+#: src/preferences/devices/airpods/configureWindow.js:123
+msgid "Automatically pause or resume playback based on wearing detection."
+msgstr "Wiedergabe automatisch anhalten oder fortsetzen basierend auf der Trageerkennung."
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:246
+msgid "Voice detection"
+msgstr "Stimmerkennung"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:249
+msgid "5 seconds"
+msgstr "5 Sekunden"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:249
+msgid "10 seconds"
+msgstr "10 Sekunden"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:249
+msgid "15 seconds"
+msgstr "15 Sekunden"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:252
+#: src/preferences/devices/sony/configureWindow.js:134
+msgid "Duration"
+msgstr "Dauer"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:272
+#: src/preferences/devices/sony/configureWindow.js:222
+msgid "Bass Boost"
+msgstr "Bass-Verstärkung"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:273
+msgid "Soft"
+msgstr "Weich"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:274
+msgid "Dynamic"
+msgstr "Dynamisch"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:275
+msgid "Clear"
+msgstr "Klar"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:276
+#: src/preferences/devices/sony/configureWindow.js:221
+msgid "Treble Boost"
+msgstr "Höhen-Verstärkung"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:306
+msgid "Balance"
+msgstr "Balance"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:310
+msgid "Left"
+msgstr "Links"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:311
+msgid "Center"
+msgstr "Mitte"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:312
+msgid "Right"
+msgstr "Rechts"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:330
+msgid "Earbuds Controls"
+msgstr "Ohrhörer-Steuerung"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:336
+msgid "Media Controls (Pinch And Swipe)"
+msgstr "Mediensteuerung (Drücken und Wischen)"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:336
+msgid "Enable Touch Controls "
+msgstr "Berührungssteuerung aktivieren "
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:392
+msgid "Touch and Hold"
+msgstr "Berühren und Halten"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:411
+msgid "Pinch to Answer Call or End Call"
+msgstr "Drücken zum Annehmen oder Beenden eines Anrufs"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:412
+msgid "Double Tap to Answer Call or End Call"
+msgstr "Doppeltippen zum Annehmen oder Beenden eines Anrufs"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:426
+msgid "Pinch and Hold to Decline Call"
+msgstr "Drücken und Halten zum Ablehnen eines Anrufs"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:427
+msgid "Touch and Hold to Decline Call"
+msgstr "Berühren und Halten zum Ablehnen eines Anrufs"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:463
+msgid "Quick Ambient Sound"
+msgstr "Schneller Umgebungston"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:465
+msgid "Ambient Sound"
+msgstr "Umgebungston"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:466
+msgid "Spotify Spot On"
+msgstr "Spotify Spot On"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:468
+msgid "ANC"
+msgstr "ANC"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:484
+msgid "Left Earbud Pinch and Hold Function"
+msgstr "Funktion „Drücken und Halten“ – linker Ohrhörer"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:485
+msgid "Left Earbud Touch and Hold Function"
+msgstr "Funktion „Berühren und Halten“ – linker Ohrhörer"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:488
+msgid "Right Earbud Pinch and Hold Function"
+msgstr "Funktion „Drücken und Halten“ – rechter Ohrhörer"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:489
+msgid "Right Earbud Touch and Hold Function"
+msgstr "Funktion „Berühren und Halten“ – rechter Ohrhörer"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:529
+#: src/preferences/devices/airpods/configureWindow.js:246
+#: src/lib/devices/nothingBuds/nothingBudsDevice.js:397
+#: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:616
+#: src/lib/devices/airpods/airpodsDevice.js:202
+msgid "Adaptive"
+msgstr "Adaptiv"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:542
+msgid "Select any two toggles"
+msgstr "Zwei beliebige Optionen auswählen"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:548
+msgid "Pinch and Hold Cycle for Left Earbud"
+msgstr "Drücken-und-Halten-Zyklus für linken Ohrhörer"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:549
+msgid "Pinch and hold cycles between modes (Left)"
+msgstr "Drücken und Halten wechselt zwischen Modi (Links)"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:550
+msgid "Pinch and Hold Cycle for Right Earbud"
+msgstr "Drücken-und-Halten-Zyklus für rechten Ohrhörer"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:551
+msgid "Pinch and hold cycles between modes (Right)"
+msgstr "Drücken und Halten wechselt zwischen Modi (Rechts)"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:553
+msgid "Touch and Hold Cycle for Left Earbud"
+msgstr "Berühren-und-Halten-Zyklus für linken Ohrhörer"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:554
+msgid "Touch and hold cycles between modes (Left)"
+msgstr "Berühren und Halten wechselt zwischen Modi (Links)"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:555
+msgid "Touch and Hold Cycle for Right Earbud"
+msgstr "Berühren-und-Halten-Zyklus für rechten Ohrhörer"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:556
+msgid "Touch and hold cycles between modes (Right)"
+msgstr "Berühren und Halten wechselt zwischen Modi (Rechts)"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:559
+msgid "Pinch and Hold Cycle"
+msgstr "Drücken-und-Halten-Zyklus"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:560
+msgid "Pinch and hold cycles between modes"
+msgstr "Drücken und Halten wechselt zwischen Modi"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:562
+msgid "Touch and Hold Cycle"
+msgstr "Berühren-und-Halten-Zyklus"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:563
+msgid "Touch and hold cycles between modes"
+msgstr "Berühren und Halten wechselt zwischen Modi"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:619
+msgid "Ambient Sound During Calls"
+msgstr "Umgebungston während Anrufen"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:633
+msgid "Noise Controls With One Earbud"
+msgstr "Geräuschsteuerung mit einem Ohrhörer"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:647
+msgid "Double Tap Outside Edge For Volume Controls"
+msgstr "Doppeltippen auf die Aussenkante für Lautstärkeregelung"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:690
+msgid "Left Ambient Sound Volume"
+msgstr "Lautstärke Umgebungston links"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:711
+msgid "Right Ambient Sound Volume"
+msgstr "Lautstärke Umgebungston rechts"
+
+#: src/preferences/devices/galaxyBuds/configureWindow.js:732
+msgid "Ambient Sound Tone"
+msgstr "Klang des Umgebungstons"
+
+#: src/preferences/devices/sony/configureWindow.js:113
+#: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:676
+#: src/lib/devices/sony/sonyDevice.js:195
+#: src/lib/devices/airpods/airpodsDevice.js:238
+msgid "Conversation Awareness"
+msgstr "Konversationserkennung"
+
+#: src/preferences/devices/sony/configureWindow.js:115
+#: src/preferences/devices/sony/configureWindow.js:285
+msgid "Auto"
+msgstr "Automatisch"
+
+#: src/preferences/devices/sony/configureWindow.js:115
+#: src/lib/devices/nothingBuds/nothingBudsDevice.js:394
+#: src/lib/devices/sony/sonyDevice.js:181
+msgid "High"
+msgstr "Hoch"
+
+#: src/preferences/devices/sony/configureWindow.js:115
+#: src/lib/devices/nothingBuds/nothingBudsDevice.js:396
+#: src/lib/devices/sony/sonyDevice.js:181
+msgid "Low"
+msgstr "Niedrig"
+
+#: src/preferences/devices/sony/configureWindow.js:118
+msgid "Voice Detection Sensitivity"
+msgstr "Empfindlichkeit der Stimmerkennung"
+
+#: src/preferences/devices/sony/configureWindow.js:131
+msgid "Short"
+msgstr "Kurz"
+
+#: src/preferences/devices/sony/configureWindow.js:131
+#: src/preferences/devices/sony/configureWindow.js:155
+#: src/lib/devices/sony/sonyDevice.js:181
+msgid "Standard"
+msgstr "Standard"
+
+#: src/preferences/devices/sony/configureWindow.js:131
+msgid "Long"
+msgstr "Lang"
+
+#: src/preferences/devices/sony/configureWindow.js:151
+#: src/preferences/devices/sony/configureWindow.js:167
+msgid "Listening Mode"
+msgstr "Hörmodus"
+
+#: src/preferences/devices/sony/configureWindow.js:156
+msgid "Background Music"
+msgstr "Hintergrundmusik"
+
+#: src/preferences/devices/sony/configureWindow.js:157
+msgid "Cinema"
+msgstr "Kino"
+
+#: src/preferences/devices/sony/configureWindow.js:182
+msgid "My Room"
+msgstr "Mein Zimmer"
+
+#: src/preferences/devices/sony/configureWindow.js:183
+msgid "Living Room"
+msgstr "Wohnzimmer"
+
+#: src/preferences/devices/sony/configureWindow.js:184
+msgid "Cafe"
+msgstr "Café"
+
+#: src/preferences/devices/sony/configureWindow.js:194
+msgid "Background Music Effects"
+msgstr "Hintergrundmusik-Effekte"
+
+#: src/preferences/devices/sony/configureWindow.js:216
+msgid "Bright"
+msgstr "Hell"
+
+#: src/preferences/devices/sony/configureWindow.js:217
+msgid "Excited"
+msgstr "Lebhaft"
+
+#: src/preferences/devices/sony/configureWindow.js:218
+msgid "Mellow"
+msgstr "Sanft"
+
+#: src/preferences/devices/sony/configureWindow.js:219
+msgid "Relaxed"
+msgstr "Entspannt"
+
+#: src/preferences/devices/sony/configureWindow.js:220
+msgid "Vocal"
+msgstr "Gesang"
+
+#: src/preferences/devices/sony/configureWindow.js:223
+msgid "Speech"
+msgstr "Sprache"
+
+#: src/preferences/devices/sony/configureWindow.js:224
+msgid "Manual"
+msgstr "Manuell"
+
+#: src/preferences/devices/sony/configureWindow.js:225
+msgid "Custom 1"
+msgstr "Benutzerdefiniert 1"
+
+#: src/preferences/devices/sony/configureWindow.js:226
+msgid "Custom 2"
+msgstr "Benutzerdefiniert 2"
+
+#: src/preferences/devices/sony/configureWindow.js:260
+msgid "400"
+msgstr "400"
+
+#: src/preferences/devices/sony/configureWindow.js:260
+#: src/preferences/devices/sony/configureWindow.js:262
+msgid "1k"
+msgstr "1k"
+
+#: src/preferences/devices/sony/configureWindow.js:260
+msgid "2.5k"
+msgstr "2.5k"
+
+#: src/preferences/devices/sony/configureWindow.js:260
+msgid "6.3k"
+msgstr "6.3k"
+
+#: src/preferences/devices/sony/configureWindow.js:260
+#: src/preferences/devices/sony/configureWindow.js:262
+msgid "16k"
+msgstr "16k"
+
+#: src/preferences/devices/sony/configureWindow.js:261
+msgid "31"
+msgstr "31"
+
+#: src/preferences/devices/sony/configureWindow.js:261
+msgid "63"
+msgstr "63"
+
+#: src/preferences/devices/sony/configureWindow.js:261
+msgid "125"
+msgstr "125"
+
+#: src/preferences/devices/sony/configureWindow.js:261
+msgid "250"
+msgstr "250"
+
+#: src/preferences/devices/sony/configureWindow.js:261
+msgid "500"
+msgstr "500"
+
+#: src/preferences/devices/sony/configureWindow.js:262
+msgid "2k"
+msgstr "2k"
+
+#: src/preferences/devices/sony/configureWindow.js:262
+msgid "4k"
+msgstr "4k"
+
+#: src/preferences/devices/sony/configureWindow.js:262
+msgid "8k"
+msgstr "8k"
+
+#: src/preferences/devices/sony/configureWindow.js:280
+msgid "DSEE"
+msgstr "DSEE"
+
+#: src/preferences/devices/sony/configureWindow.js:284
+msgid "Enable DSEE enhancement"
+msgstr "DSEE-Verbesserung aktivieren"
+
+#: src/preferences/devices/sony/configureWindow.js:298
+msgid "Button/Touch Settings"
+msgstr "Tasten-/Berührungseinstellungen"
+
+#: src/preferences/devices/sony/configureWindow.js:302
+msgid "Ambient Sound Control"
+msgstr "Umgebungston-Steuerung"
+
+#: src/preferences/devices/sony/configureWindow.js:303
+msgid "Ambient Sound Control / Quick Access"
+msgstr "Umgebungston-Steuerung / Schnellzugriff"
+
+#: src/preferences/devices/sony/configureWindow.js:305
+#: src/preferences/devices/sony/configureWindow.js:306
+msgid "Playback Control"
+msgstr "Wiedergabesteuerung"
+
+#: src/preferences/devices/sony/configureWindow.js:308
+msgid "Not Assigned"
+msgstr "Nicht zugewiesen"
+
+#: src/preferences/devices/sony/configureWindow.js:324
+msgid "Left Bud"
+msgstr "Linker Ohrhörer"
+
+#: src/preferences/devices/sony/configureWindow.js:338
+msgid "Right Bud"
+msgstr "Rechter Ohrhörer"
+
+#: src/preferences/devices/sony/configureWindow.js:355
+msgid "ANC Button Configuration"
+msgstr "ANC-Tastenkonfiguration"
+
+#: src/preferences/devices/sony/configureWindow.js:366
+msgid "[NC/AMB] Button Settings"
+msgstr "[NC/AMB]-Tasteneinstellungen"
+
+#: src/preferences/devices/sony/configureWindow.js:367
+msgid "Select the modes to toggle when the button is pressed"
+msgstr "Modi auswählen, zwischen denen beim Tastendruck gewechselt werden soll"
+
+#: src/preferences/devices/sony/configureWindow.js:385
+msgid "Notification"
+msgstr "Benachrichtigung"
+
+#: src/preferences/devices/sony/configureWindow.js:389
+msgid "Voice Notification"
+msgstr "Sprachbenachrichtigung"
+
+#: src/preferences/devices/sony/configureWindow.js:390
+msgid "Enable voice notification"
+msgstr "Sprachbenachrichtigung aktivieren"
+
+#: src/preferences/devices/sony/configureWindow.js:408
+msgid "Voice Notification Volume"
+msgstr "Lautstärke der Sprachbenachrichtigung"
+
+#: src/preferences/devices/sony/configureWindow.js:410
+msgid "-2"
+msgstr "-2"
+
+#: src/preferences/devices/sony/configureWindow.js:411
+msgid "-1"
+msgstr "-1"
+
+#: src/preferences/devices/sony/configureWindow.js:412
+msgid "0"
+msgstr "0"
+
+#: src/preferences/devices/sony/configureWindow.js:413
+msgid "+1"
+msgstr "+1"
+
+#: src/preferences/devices/sony/configureWindow.js:414
+msgid "+2"
+msgstr "+2"
+
+#: src/preferences/devices/sony/configureWindow.js:433
+msgid "Headset Take off"
+msgstr "Headset abnehmen"
+
+#: src/preferences/devices/sony/configureWindow.js:440
+msgid "Pause when taken off"
+msgstr "Pausieren beim Abnehmen"
+
+#: src/preferences/devices/sony/configureWindow.js:454
+msgid "Automatically Power Off"
+msgstr "Automatisches Ausschalten"
+
+#: src/preferences/devices/sony/configureWindow.js:455
+msgid "Automatically power off when not worn."
+msgstr "Automatisch ausschalten, wenn nicht getragen."
+
+#: src/preferences/devices/sony/configureWindow.js:470
+msgid "After 5 minutes"
+msgstr "Nach 5 Minuten"
+
+#: src/preferences/devices/sony/configureWindow.js:471
+msgid "After 15 minutes"
+msgstr "Nach 15 Minuten"
+
+#: src/preferences/devices/sony/configureWindow.js:472
+msgid "After 30 minutes"
+msgstr "Nach 30 Minuten"
+
+#: src/preferences/devices/sony/configureWindow.js:473
+msgid "After 1 hour"
+msgstr "Nach 1 Stunde"
+
+#: src/preferences/devices/sony/configureWindow.js:474
+msgid "After 3 hours"
+msgstr "Nach 3 Stunden"
+
+#: src/preferences/devices/sony/configureWindow.js:486
+msgid "Auto Power Off"
+msgstr "Automatisches Ausschalten"
+
+#: src/preferences/devices/airpods/configureWindow.js:114
+msgid "Resume when worn"
+msgstr "Fortsetzen beim Tragen"
+
+#: src/preferences/devices/airpods/configureWindow.js:139
+msgid "Volume Level"
+msgstr "Lautstärke"
+
+#: src/preferences/devices/airpods/configureWindow.js:143
+msgid "Pause when device is not worn"
+msgstr "Pausieren, wenn das Gerät nicht getragen wird"
+
+#: src/preferences/devices/airpods/configureWindow.js:144
+msgid "Pause playback when the device is removed,resume when it is put back on"
+msgstr "Wiedergabe pausieren, wenn das Gerät abgenommen wird, und fortsetzen, wenn es wieder aufgesetzt wird"
+
+#: src/preferences/devices/airpods/configureWindow.js:163
+msgid "Conversation awareness volume limit"
+msgstr "Lautstärkebegrenzung der Konversationserkennung"
+
+#: src/preferences/devices/airpods/configureWindow.js:164
+msgid ""
+"Limits media volume to this percentage during conversation. Note: No change "
+"if current volume is below this level."
+msgstr ""
+"Begrenzt die Medienlautstärke während eines Gesprächs auf diesen Prozentsatz. "
+"Hinweis: Keine Änderung, wenn die aktuelle Lautstärke unter diesem Wert liegt."
+
+#: src/preferences/devices/airpods/configureWindow.js:187
+msgid "Turn off listening modes"
+msgstr "Hörmodi deaktivieren"
+
+#: src/preferences/devices/airpods/configureWindow.js:191
+msgid "Allows to turn off all listening mode technology"
+msgstr "Ermöglicht das Deaktivieren aller Hörmodus-Technologien"
+
+#: src/preferences/devices/airpods/configureWindow.js:192
+msgid ""
+"Allows Noise Cancellation, Transparency, and Adaptive modes to be fully "
+"disabled. Disabling listening modes also turns off Hearing Aid features and "
+"reduces power usage."
+msgstr ""
+"Ermöglicht das vollständige Deaktivieren von Geräuschunterdrückung, "
+"Transparenz und adaptivem Modus. Das Deaktivieren der Hörmodi schaltet auch "
+"Hörgerätefunktionen ab und reduziert den Energieverbrauch."
+
+#: src/preferences/devices/airpods/configureWindow.js:233
+#: src/lib/devices/nothingBuds/nothingBudsDevice.js:375
+#: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:615
+#: src/lib/devices/airpods/airpodsDevice.js:201
+msgid "Transparency"
+msgstr "Transparenz"
+
+#: src/preferences/devices/airpods/configureWindow.js:255
+msgid "Press and Hold Cycle"
+msgstr "Drücken-und-Halten-Zyklus"
+
+#: src/preferences/devices/airpods/configureWindow.js:258
+msgid "Press and hold cycles between"
+msgstr "Drücken und Halten wechselt zwischen"
+
+#: src/preferences/devices/airpods/configureWindow.js:259
+msgid "Settings don’t reflect current state"
+msgstr "Einstellungen spiegeln den aktuellen Zustand nicht wider"
+
+#: src/preferences/devices/airpods/configureWindow.js:286
+msgid "Notification Volume"
+msgstr "Benachrichtigungslautstärke"
+
+#: src/preferences/devices/airpods/configureWindow.js:290
+msgid "Tone Volume"
+msgstr "Klanglautstärke"
+
+#: src/preferences/devices/airpods/configureWindow.js:291
+msgid "Adjust the tone volume of sound effects played by AirPods"
+msgstr "Lautstärke der von den AirPods abgespielten Soundeffekte anpassen"
+
+#: src/preferences/devices/airpods/configureWindow.js:293
+msgid "15%"
+msgstr "15 %"
+
+#: src/preferences/devices/airpods/configureWindow.js:294
+msgid "100%"
+msgstr "100 %"
+
+#: src/preferences/devices/airpods/configureWindow.js:295
+msgid "125%"
+msgstr "125 %"
+
+#: src/preferences/devices/airpods/configureWindow.js:316
+msgid "Volume Swipe"
+msgstr "Lautstärke-Wischen"
+
+#: src/preferences/devices/airpods/configureWindow.js:317
+msgid "Enable or disable volume adjustment by swiping on earbud stems"
+msgstr "Lautstärkeanpassung durch Wischen auf den Stielen der Ohrhörer aktivieren oder deaktivieren"
+
+#: src/preferences/devices/airpods/configureWindow.js:326
+#: src/preferences/devices/airpods/configureWindow.js:359
+#: src/preferences/devices/airpods/configureWindow.js:377
+msgid "Default"
+msgstr "Standard"
+
+#: src/preferences/devices/airpods/configureWindow.js:326
+#: src/preferences/devices/airpods/configureWindow.js:359
+msgid "Longer"
+msgstr "Länger"
+
+#: src/preferences/devices/airpods/configureWindow.js:326
+#: src/preferences/devices/airpods/configureWindow.js:359
+msgid "Longest"
+msgstr "Am längsten"
+
+#: src/preferences/devices/airpods/configureWindow.js:330
+msgid "Swipe Duration"
+msgstr "Wisch-Dauer"
+
+#: src/preferences/devices/airpods/configureWindow.js:331
+msgid ""
+"To prevent unintended adjustments,select the preferred wait time between "
+"swipes"
+msgstr ""
+"Um ungewollte Anpassungen zu vermeiden, wählen Sie die bevorzugte Wartezeit "
+"zwischen Wischbewegungen"
+
+#: src/preferences/devices/airpods/configureWindow.js:356
+msgid "Stem and Crown Response"
+msgstr "Reaktion von Stiel und Digital Crown"
+
+#: src/preferences/devices/airpods/configureWindow.js:363
+msgid "Press Speed"
+msgstr "Druckgeschwindigkeit"
+
+#: src/preferences/devices/airpods/configureWindow.js:364
+msgid ""
+"Adjust how quickly you must double or triple-press the stem or Digital Crown "
+"before an action occurs"
+msgstr ""
+"Legt fest, wie schnell der Stiel oder die Digital Crown doppelt oder "
+"dreifach gedrückt werden muss, bevor eine Aktion ausgelöst wird"
+
+#: src/preferences/devices/airpods/configureWindow.js:377
+msgid "Shorter"
+msgstr "Kürzer"
+
+#: src/preferences/devices/airpods/configureWindow.js:377
+msgid "Shortest"
+msgstr "Am kürzesten"
+
+#: src/preferences/devices/airpods/configureWindow.js:380
+msgid "Press and Hold Duration"
+msgstr "Dauer von Drücken und Halten"
+
+#: src/preferences/devices/airpods/configureWindow.js:381
+msgid "Set how long you need to press and hold before an action occurs"
+msgstr "Legt fest, wie lange gedrückt und gehalten werden muss, bevor eine Aktion ausgelöst wird"
+
+#: src/preferences/widgets/ringMyBudsRow.js:21
+msgid "Find my earbuds"
+msgstr "Meine Ohrhörer finden"
+
+#: src/preferences/widgets/ringMyBudsRow.js:32
+#: src/preferences/widgets/ringMyBudsRow.js:53
+#: src/preferences/widgets/ringMyBudsRow.js:97
+#: src/preferences/widgets/ringMyBudsRow.js:142
+msgid "Play"
+msgstr "Abspielen"
+
+#: src/preferences/widgets/ringMyBudsRow.js:94
+msgid "Stop"
+msgstr "Stopp"
+
+#: src/preferences/widgets/ringMyBudsRow.js:133
+msgid "Continue?"
+msgstr "Fortfahren?"
+
+#: src/preferences/widgets/ringMyBudsRow.js:135
+msgid ""
+"Your earbuds/headset may be in use. Be sure to remove them from your ears "
+"before you continue. A loud sound will be played which could be "
+"uncomfortable for anyone wearing them."
+msgstr ""
+"Ihre Ohrhörer/Ihr Headset werden möglicherweise gerade benutzt. Stellen Sie "
+"sicher, dass Sie sie aus den Ohren nehmen, bevor Sie fortfahren. Es wird ein "
+"lauter Ton abgespielt, der für Träger unangenehm sein kann."
+
+#: src/preferences/widgets/ringMyBudsRow.js:141
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: src/preferences/widgets/iconSelectorWidget.js:47
+#: src/preferences/widgets/iconSelectorWidget.js:65
+msgid "Device information"
+msgstr "Geräteinformationen"
+
+#: src/preferences/widgets/iconSelectorWidget.js:78
+msgid "Mac Address"
+msgstr "MAC-Adresse"
+
+#: src/preferences/widgets/iconSelectorWidget.js:100
+msgid "Firmware Version"
+msgstr "Firmware-Version"
+
+#: src/lib/devices/nothingBuds/nothingBudsDevice.js:391
+#: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:654
+#: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:665
+msgid "Noise Cancellation Level"
+msgstr "Stufe der Geräuschunterdrückung"
+
+#: src/lib/devices/nothingBuds/nothingBudsDevice.js:427
+msgid "Personalised ANC"
+msgstr "Personalisiertes ANC"
+
+#: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:652
+#: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:662
+#: src/lib/devices/sony/sonyDevice.js:174
+#: src/lib/devices/airpods/airpodsDevice.js:232
+msgid "Ambient Level"
+msgstr "Umgebungston-Stufe"
+
+#: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:658
+#: src/lib/devices/sony/sonyDevice.js:177
+#: src/lib/devices/sony/sonyDevice.js:179
+#: src/lib/devices/sony/sonyDevice.js:183
+msgid "Focus on Voice"
+msgstr "Stimmfokus"
+
+#: src/lib/devices/sony/sonyDevice.js:177
+#: src/lib/devices/sony/sonyDevice.js:179
+msgid "Auto Ambient"
+msgstr "Automatische Umgebung"
+
+#: src/lib/devices/sony/sonyDevice.js:180
+msgid "Auto Ambient Sensitivity"
+msgstr "Empfindlichkeit der automatischen Umgebung"
+
+#: src/lib/devices/notifier.js:19
+msgid "AirPods / Beats"
+msgstr "AirPods / Beats"
+
+#: src/lib/devices/notifier.js:21
+msgid "Sony audio devices"
+msgstr "Sony-Audiogeräte"
+
+#: src/lib/devices/notifier.js:23
+msgid "Samsung Galaxy Buds"
+msgstr "Samsung Galaxy Buds"
+
+#: src/lib/devices/notifier.js:25
+msgid "Nothing / CMF Buds"
+msgstr "Nothing / CMF Buds"
+
+#: src/lib/devices/notifier.js:31
+#, javascript-format
+msgid "Could not access advanced features for %s."
+msgstr "Auf erweiterte Funktionen für %s konnte nicht zugegriffen werden."
+
+#: src/lib/devices/notifier.js:34
+#, javascript-format
+msgid ""
+"Another app or session is already using the Bluetooth socket/profile on %s. "
+"Close any other apps using this device, then restart this app."
+msgstr ""
+"Eine andere Anwendung oder Sitzung verwendet bereits den Bluetooth-Socket "
+"bzw. das Profil von %s. Beenden Sie andere Anwendungen, die dieses Gerät "
+"nutzen, und starten Sie diese Anwendung neu."


### PR DESCRIPTION
Based on the German (de) translation (https://github.com/maniacx/BudsLink/pull/34), with the single ß replaced by
ss ("Außenkante" → "Aussenkante") to follow Swiss orthography.