### PR TITLE
Add Google Pixel Buds support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@
 
 
 ### Disclaimer
-**This project is an independent effort and is not affiliated with, endorsed by, or sponsored by Apple, Sony, Samsung, or Nothing. All product and company names are trademarks™ or registered® trademarks of their respective holders and are used for identification purposes only.**
-
+**This project is an independent effort and is not affiliated with, endorsed by, or sponsored by Apple, Sony, Samsung, Google, or Nothing. All product and company names are trademarks™ or registered® trademarks of their respective holders and are used for identification purposes only.**
 
 
 

--- a/data/io.github.maniacx.BudsLink.desktop
+++ b/data/io.github.maniacx.BudsLink.desktop
@@ -6,5 +6,4 @@ Exec=@BINDIR@/@APP_COMMAND@
 Type=Application
 DBusActivatable=true
 Categories=Audio;Utility;
-Keywords=Bluetooth;Earbuds;Headphones;Battery;ANC;TouchControls;Sony;AirPods;Beats;Samsung,Galaxy,Buds,Nothing,CMF
-
+Keywords=Bluetooth;Earbuds;Headphones;Battery;ANC;TouchControls;Sony;AirPods;Beats;Samsung;Galaxy;Buds;Nothing;CMF;Google;Pixel;

--- a/data/io.github.maniacx.BudsLink.gschema.xml
+++ b/data/io.github.maniacx.BudsLink.gschema.xml
@@ -25,5 +25,8 @@
         <key name="nothing-buds-list" type="as">
             <default>[]</default>
         </key>
+        <key name="google-buds-list" type="as">
+            <default>[]</default>
+        </key>
 	</schema>
 </schemalist>

--- a/data/io.github.maniacx.BudsLink.metainfo.xml
+++ b/data/io.github.maniacx.BudsLink.metainfo.xml
@@ -4,8 +4,8 @@
   <name>BudsLink</name>
   <summary>Monitor and control Bluetooth earbuds</summary>
   <description>
-    <p>BudsLink provides comprehensive battery monitoring and feature control for supported Bluetooth wearable audio devices, including popular models from Apple, Beats, and Sony. The application communicates directly with supported devices to expose battery levels, noise control modes, and advanced interaction features when available, offering a consistent and configurable interface across different vendors.</p>
-    <p>This application is an independent project and is not affiliated with, endorsed by, or sponsored by Apple, Sony, Samsung, or Nothing.</p>
+    <p>BudsLink provides comprehensive battery monitoring and feature control for supported Bluetooth wearable audio devices, including popular models from Apple, Beats, Sony, Samsung, Google, and Nothing. The application communicates directly with supported devices to expose battery levels, noise control modes, and advanced interaction features when available, offering a consistent and configurable interface across different vendors.</p>
+    <p>This application is an independent project and is not affiliated with, endorsed by, or sponsored by Apple, Sony, Samsung, Google, or Nothing.</p>
     <ul>
       <li>Monitor earbud and charging case battery levels</li>
       <li>Control Active Noise Cancellation and ambient sound modes</li>
@@ -21,6 +21,7 @@
       <li>Airpods / Beats</li>
       <li>Sony</li>
       <li>Samsung Galaxy Buds</li>
+      <li>Google Pixel Buds</li>
       <li>Nothing / CMF</li>
     </ul>
   </description>
@@ -39,6 +40,8 @@
     <keyword>Buds</keyword>
     <keyword>Nothing</keyword>
     <keyword>CMF</keyword>
+    <keyword>Google</keyword>
+    <keyword>Pixel</keyword>
   </keywords>
   <metadata_license>CC-BY-SA-4.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>

--- a/src/app.js
+++ b/src/app.js
@@ -145,6 +145,7 @@ export const BudsLinkApplication = GObject.registerClass({
         this.sonyEnabled = true;
         this.galaxyBudsEnabled = true;
         this.nothingBudsEnabled = true;
+        this.googleBudsEnabled = true;
         this._client = new BluetoothClient();
         this._deviceManager = new EnhancedDeviceSupportManager(this);
         this._initialize();
@@ -327,4 +328,3 @@ export const BudsLinkApplication = GObject.registerClass({
         this.settings = null;
     }
 });
-

--- a/src/appLibs/confirueWindowlauncher.js
+++ b/src/appLibs/confirueWindowlauncher.js
@@ -2,6 +2,7 @@ import * as Airpods from '../preferences/devices/airpods/configureWindow.js';
 import * as Sony from '../preferences/devices/sony/configureWindow.js';
 import * as GalaxyBuds from '../preferences/devices/galaxyBuds/configureWindow.js';
 import * as NothingBuds from '../preferences/devices/nothingBuds/configureWindow.js';
+import * as GoogleBuds from '../preferences/devices/googleBuds/configureWindow.js';
 
 let _settings = null;
 let _gettext = null;
@@ -45,6 +46,10 @@ export function createConfigureWindow({
             Prefs = NothingBuds;
             schemaKey = 'nothing-buds-list';
             break;
+        case 'googleBuds':
+            Prefs = GoogleBuds;
+            schemaKey = 'google-buds-list';
+            break;
         default:
             return null;
     }
@@ -68,4 +73,3 @@ export function createConfigureWindow({
         false
     );
 }
-

--- a/src/appLibs/dbusService.js
+++ b/src/appLibs/dbusService.js
@@ -293,7 +293,7 @@ class DbusService extends GObject.Object {
             GLib.Variant.new('(o)', [objectPath])
         );
 
-        this._log.info(`Device added: ${objectPath}`);
+        this._log.info(`Device added: ${this._safeDevicePath(objectPath)}`);
     }
 
     removeDevice(devicePath) {
@@ -312,7 +312,14 @@ class DbusService extends GObject.Object {
             GLib.Variant.new('(o)', [objectPath])
         );
 
-        this._log.info(`Device removed: ${objectPath}`);
+        this._log.info(`Device removed: ${this._safeDevicePath(objectPath)}`);
+    }
+
+    _safeDevicePath(path) {
+        return path.replace(
+            /dev_([0-9A-Fa-f]{2}_){5}[0-9A-Fa-f]{2}/,
+            'dev_XX_XX_XX_XX_XX_XX'
+        );
     }
 
     destroy() {

--- a/src/io.github.maniacx.BudsLink.src.gresource.xml
+++ b/src/io.github.maniacx.BudsLink.src.gresource.xml
@@ -84,6 +84,11 @@
         <file>lib/devices/nothingBuds/nothingBudsDevice.js</file>
         <file>lib/devices/nothingBuds/nothingBudsSocket.js</file>
 
+        <file>lib/devices/googleBuds/googleBudsConfig.js</file>
+        <file>lib/devices/googleBuds/googleBudsDevice.js</file>
+        <file>lib/devices/googleBuds/googleBudsProtocol.js</file>
+        <file>lib/devices/googleBuds/googleBudsSocket.js</file>
+
         <file>lib/devices/nothingBuds/deviceConfigs/BudsPro.js</file>
         <file>lib/devices/nothingBuds/deviceConfigs/CMFBuds.js</file>
         <file>lib/devices/nothingBuds/deviceConfigs/CMFBuds2.js</file>
@@ -143,6 +148,7 @@
 
         <file>preferences/devices/airpods/configureWindow.js</file>
         <file>preferences/devices/galaxyBuds/configureWindow.js</file>
+        <file>preferences/devices/googleBuds/configureWindow.js</file>
         <file>preferences/devices/nothingBuds/configureWindow.js</file>
         <file>preferences/devices/sony/configureWindow.js</file>
         <file>preferences/widgets/checkBoxesRowWidget.js</file>

--- a/src/lib/bluezDeviceProxy.js
+++ b/src/lib/bluezDeviceProxy.js
@@ -5,6 +5,7 @@ const BluezDeviceInterface = `
   <interface name="org.bluez.Device1">
     <property name="Alias" type="s" access="read"/>
     <property name="Connected" type="b" access="read"/>
+    <property name="Class" type="u" access="read"/>
     <property name="Paired" type="b" access="read"/>
     <property name="Modalias" type="s" access="read"/>
     <property name="Icon" type="s" access="read"/>

--- a/src/lib/bluezDeviceProxy.js
+++ b/src/lib/bluezDeviceProxy.js
@@ -5,7 +5,6 @@ const BluezDeviceInterface = `
   <interface name="org.bluez.Device1">
     <property name="Alias" type="s" access="read"/>
     <property name="Connected" type="b" access="read"/>
-    <property name="Class" type="u" access="read"/>
     <property name="Paired" type="b" access="read"/>
     <property name="Modalias" type="s" access="read"/>
     <property name="Icon" type="s" access="read"/>

--- a/src/lib/devices/googleBuds/googleBudsConfig.js
+++ b/src/lib/devices/googleBuds/googleBudsConfig.js
@@ -1,0 +1,118 @@
+'use strict';
+
+export const DeviceTypeGoogleBuds = 'googleBuds';
+
+export const MaestroUUID = '25e97ff7-24ce-4c4c-8951-f764a708f7b5';
+
+export const PixelBudsClass = 0x240404;
+export const PixelBuds2Class = 0x244404;
+
+export const PacketType = {
+    REQUEST: 0,
+    RESPONSE: 1,
+    CLIENT_ERROR: 4,
+    SERVER_ERROR: 5,
+    SERVER_STREAM: 7,
+};
+
+export const Status = {
+    OK: 0,
+    FAILED_PRECONDITION: 9,
+};
+
+export const MaestroService = 0x7ede71ea;
+
+export const MaestroMethod = {
+    GET_SOFTWARE_INFO: 0x7199fa44,
+    SUBSCRIBE_RUNTIME_INFO: 0xe61e8290,
+    SUBSCRIBE_SETTINGS_CHANGES: 0x2821adf5,
+    WRITE_SETTING: 0x9e8c9a1d,
+    READ_SETTING: 0xaed0ae51,
+};
+
+export const BatteryState = {
+    UNKNOWN: 0,
+    NOT_CHARGING: 1,
+    CHARGING: 2,
+};
+
+export const SettingId = {
+    ANCR_GESTURE_LOOP: 12,
+    CURRENT_ANCR_STATE: 13,
+    VOLUME_EQ_ENABLE: 15,
+    CURRENT_USER_EQ: 16,
+    LAST_SAVED_USER_EQ: 18,
+};
+
+export const AncState = {
+    OFF: 1,
+    ACTIVE: 2,
+    AWARE: 3,
+    ADAPTIVE: 4,
+};
+
+export const EqPreset = {
+    DEFAULT: 'default',
+    HEAVY_BASS: 'heavy-bass',
+    LIGHT_BASS: 'light-bass',
+    BALANCED: 'balanced',
+    VOCAL_BOOST: 'vocal-boost',
+    CLARITY: 'clarity',
+    LAST_SAVED: 'last-saved',
+    CUSTOM: 'custom',
+};
+
+// Presets are applied by writing these bands to CURRENT_USER_EQ.
+// LAST_SAVED_USER_EQ is read separately at runtime.
+export const EqPresetBands = {
+    [EqPreset.DEFAULT]: [0, 0, 0, 0, 0],
+    [EqPreset.HEAVY_BASS]: [5, 3, 0, 0, 0],
+    [EqPreset.LIGHT_BASS]: [-5, -1, 0, 0, 0],
+    [EqPreset.BALANCED]: [-3, 1, 1, -1, 3],
+    [EqPreset.VOCAL_BOOST]: [-1, 0, 4, 2, 0],
+    [EqPreset.CLARITY]: [-2, 0, 2, 3, 5],
+};
+
+export function eqPresetForBands(eqBands) {
+    const roundedBands = eqBands.map(value => Math.round(value));
+
+    for (const [preset, bands] of Object.entries(EqPresetBands)) {
+        if (JSON.stringify(roundedBands) === JSON.stringify(bands))
+            return preset;
+    }
+
+    return EqPreset.CUSTOM;
+}
+
+export const Peer = {
+    CASE: 2,
+    LEFT_BT_CORE: 3,
+    RIGHT_BT_CORE: 4,
+    MAESTRO_A: 10,
+    MAESTRO_B: 13,
+};
+
+export const CandidateChannels = [18, 19, 21, 23, 24, 26];
+
+export function addressForChannel(channel) {
+    switch (channel) {
+        case 18:
+            return addressFromPeers(Peer.MAESTRO_A, Peer.CASE);
+        case 19:
+            return addressFromPeers(Peer.MAESTRO_A, Peer.LEFT_BT_CORE);
+        case 21:
+            return addressFromPeers(Peer.MAESTRO_A, Peer.RIGHT_BT_CORE);
+        case 23:
+            return addressFromPeers(Peer.MAESTRO_B, Peer.CASE);
+        case 24:
+            return addressFromPeers(Peer.MAESTRO_B, Peer.LEFT_BT_CORE);
+        case 26:
+            return addressFromPeers(Peer.MAESTRO_B, Peer.RIGHT_BT_CORE);
+        default:
+            return null;
+    }
+}
+
+function addressFromPeers(source, target) {
+    return (source & 0x0f) << 6 | (target & 0x0f) << 10;
+}

--- a/src/lib/devices/googleBuds/googleBudsConfig.js
+++ b/src/lib/devices/googleBuds/googleBudsConfig.js
@@ -4,9 +4,6 @@ export const DeviceTypeGoogleBuds = 'googleBuds';
 
 export const MaestroUUID = '25e97ff7-24ce-4c4c-8951-f764a708f7b5';
 
-export const PixelBudsClass = 0x240404;
-export const PixelBuds2Class = 0x244404;
-
 export const PacketType = {
     REQUEST: 0,
     RESPONSE: 1,

--- a/src/lib/devices/googleBuds/googleBudsDevice.js
+++ b/src/lib/devices/googleBuds/googleBudsDevice.js
@@ -10,26 +10,16 @@ import {
 import {createConfig, createProperties, DataHandler} from '../../dataHandler.js';
 import {GoogleBudsSocket} from './googleBudsSocket.js';
 import {
-    AncState, DeviceTypeGoogleBuds, EqPreset, MaestroUUID, PixelBudsClass, PixelBuds2Class,
-    eqPresetForBands
+    AncState, DeviceTypeGoogleBuds, EqPreset, MaestroUUID, eqPresetForBands
 } from './googleBudsConfig.js';
 
 export {DeviceTypeGoogleBuds};
 
 export function isGoogleBuds(bluezDeviceProxy, uuids) {
-    const bluezProps = ['Class'];
+    const bluezProps = [];
     let supported = 'no';
 
-    if (!uuids.includes(MaestroUUID))
-        return {supported, bluezProps};
-
-    const deviceClass = bluezDeviceProxy.Class;
-    if (deviceClass === null || deviceClass === undefined) {
-        supported = 'pending';
-        return {supported, bluezProps};
-    }
-
-    if (deviceClass === PixelBudsClass || deviceClass === PixelBuds2Class)
+    if (uuids.includes(MaestroUUID))
         supported = 'yes';
 
     return {supported, bluezProps};

--- a/src/lib/devices/googleBuds/googleBudsDevice.js
+++ b/src/lib/devices/googleBuds/googleBudsDevice.js
@@ -197,6 +197,7 @@ export const GoogleBudsDevice = GObject.registerClass({
     }
 
     _updateAncConfig(enabledModes = {off: true, aware: true, active: true, adaptive: false}) {
+        this._ancEnabledModes = {...enabledModes};
         this._config.toggle1Title = _('Noise Control');
 
         for (let i = 1; i <= 4; i++) {
@@ -262,7 +263,7 @@ export const GoogleBudsDevice = GObject.registerClass({
             off: true,
             aware: true,
             active: true,
-            adaptive: gestureLoop.adaptive,
+            adaptive: gestureLoop.adaptive || this._ancState === AncState.ADAPTIVE,
         };
         this._updateAncConfig(enabledModes);
     }
@@ -301,6 +302,10 @@ export const GoogleBudsDevice = GObject.registerClass({
     }
 
     updateAncState(ancState) {
+        this._ancState = ancState;
+        if (ancState === AncState.ADAPTIVE && !this._ancStateToToggle1Button?.[ancState])
+            this._updateAncConfig({...this._ancEnabledModes, adaptive: true});
+
         const toggleState = this._ancStateToToggle1Button?.[ancState] ?? 0;
         this._props.toggle1State = toggleState;
         this.dataHandler?.setProps(this._props);

--- a/src/lib/devices/googleBuds/googleBudsDevice.js
+++ b/src/lib/devices/googleBuds/googleBudsDevice.js
@@ -1,0 +1,408 @@
+'use strict';
+import Gio from 'gi://Gio';
+import GObject from 'gi://GObject';
+import {gettext as _} from 'gettext';
+
+import {createLogger} from '../logger.js';
+import {
+    buds2to1BatteryLevel, launchConfigureWindow, validateProperties
+} from '../deviceUtils.js';
+import {createConfig, createProperties, DataHandler} from '../../dataHandler.js';
+import {GoogleBudsSocket} from './googleBudsSocket.js';
+import {
+    AncState, DeviceTypeGoogleBuds, EqPreset, MaestroUUID, PixelBudsClass, PixelBuds2Class,
+    eqPresetForBands
+} from './googleBudsConfig.js';
+
+export {DeviceTypeGoogleBuds};
+
+export function isGoogleBuds(bluezDeviceProxy, uuids) {
+    const bluezProps = ['Class'];
+    let supported = 'no';
+
+    if (!uuids.includes(MaestroUUID))
+        return {supported, bluezProps};
+
+    const deviceClass = bluezDeviceProxy.Class;
+    if (deviceClass === null || deviceClass === undefined) {
+        supported = 'pending';
+        return {supported, bluezProps};
+    }
+
+    if (deviceClass === PixelBudsClass || deviceClass === PixelBuds2Class)
+        supported = 'yes';
+
+    return {supported, bluezProps};
+}
+
+export const GoogleBudsDevice = GObject.registerClass({
+    GTypeName: 'BudsLink_GoogleBudsDevice',
+}, class GoogleBudsDevice extends GObject.Object {
+    _init(settings, devicePath, alias, extPath, profileManager, updateDeviceMapCb) {
+        super._init();
+        const identifier = devicePath.slice(-2);
+        const tag = `GoogleBudsDevice-${identifier}`;
+        this._log = createLogger(tag);
+        this._log.info('------------------- GoogleBudsDevice init -------------------');
+        this._settings = settings;
+        this._devicePath = devicePath;
+        this._alias = alias;
+        this._extPath = extPath;
+        this.updateDeviceMapCb = updateDeviceMapCb;
+
+        this._battInfoRecieved = false;
+        this._config = createConfig();
+        this._props = createProperties();
+
+        this._callbacks = {
+            updateBatteryProps: this.updateBatteryProps.bind(this),
+            updateAncState: this.updateAncState.bind(this),
+            updateAncGestureLoop: this.updateAncGestureLoop.bind(this),
+            updateVolumeEqEnable: this.updateVolumeEqEnable.bind(this),
+            updateEq: this.updateEq.bind(this),
+            updateLastSavedEq: this.updateLastSavedEq.bind(this),
+        };
+
+        this._initialize(profileManager);
+    }
+
+    _initialize(profileManager) {
+        this._commonIcon = 'earbuds';
+        this._caseIcon = 'case-oval';
+
+        this._config.commonIcon = this._commonIcon;
+        this._config.albumArtIcon = this._commonIcon;
+        this._config.battery1Icon = `${this._commonIcon}-left`;
+        this._config.battery2Icon = `${this._commonIcon}-right`;
+        this._config.battery3Icon = this._caseIcon;
+        this._config.battery1ShowOnDisconnect = true;
+        this._config.battery2ShowOnDisconnect = true;
+        this._config.showSettingsButton = true;
+        this._updateAncConfig();
+        this._createDefaultSettings();
+        this._ensureSettings();
+        this._updateInitialValues();
+        this._monitorGoogleBudsListGsettings(true);
+
+        const profile = {type: DeviceTypeGoogleBuds, uuid: MaestroUUID};
+
+        this._googleBudsSocket = new GoogleBudsSocket(
+            this._devicePath,
+            profileManager,
+            profile,
+            this._callbacks
+        );
+    }
+
+    _createDefaultSettings() {
+        this._defaultsDeviceSettings = {
+            path: this._devicePath,
+            name: 'Pixel Buds',
+            alias: this._alias,
+            icon: this._commonIcon,
+            'volume-eq': false,
+            'eq-preset': EqPreset.CUSTOM,
+            'eq-custom': [0, 0, 0, 0, 0],
+            'eq-last-saved': [0, 0, 0, 0, 0],
+        };
+    }
+
+    _ensureSettings() {
+        const devicesList = this._settings.get_strv('google-buds-list').map(JSON.parse);
+
+        if (devicesList.length === 0 ||
+                !devicesList.some(device => device.path === this._devicePath)) {
+            devicesList.push(this._defaultsDeviceSettings);
+            this._settings.set_strv('google-buds-list', devicesList.map(JSON.stringify));
+            return;
+        }
+
+        validateProperties(this._settings, 'google-buds-list', devicesList,
+            this._defaultsDeviceSettings, this._devicePath);
+    }
+
+    _updateInitialValues() {
+        const devicesList = this._settings.get_strv('google-buds-list').map(JSON.parse);
+        const existingPathIndex = devicesList.findIndex(item => item.path === this._devicePath);
+        if (existingPathIndex === -1)
+            return;
+
+        this._settingsItems = devicesList[existingPathIndex];
+        this._commonIcon = this._settingsItems.icon;
+        this._volumeEq = this._settingsItems['volume-eq'];
+        this._eqPreset = this._settingsItems['eq-preset'];
+        this._eqCustom = this._settingsItems['eq-custom'];
+        this._eqLastSaved = this._settingsItems['eq-last-saved'];
+        this._updateIcons();
+    }
+
+    _updateIcons() {
+        this._config.commonIcon = this._commonIcon;
+        this._config.albumArtIcon = this._commonIcon;
+        this._config.battery1Icon = `${this._commonIcon}-left`;
+        this._config.battery2Icon = `${this._commonIcon}-right`;
+        this._config.battery3Icon = this._caseIcon;
+        this.dataHandler?.setConfig(this._config);
+    }
+
+    _monitorGoogleBudsListGsettings(monitor) {
+        if (monitor) {
+            if (this._settingsHandlerId)
+                this._settings?.disconnect(this._settingsHandlerId);
+
+            this._settingsHandlerId = this._settings?.connect('changed::google-buds-list', () =>
+                this._updateGsettingsProps());
+        } else {
+            if (this._settingsHandlerId)
+                this._settings?.disconnect(this._settingsHandlerId);
+            this._settingsHandlerId = null;
+        }
+    }
+
+    _updateGsettingsProps() {
+        const devicesList = this._settings.get_strv('google-buds-list').map(JSON.parse);
+        const existingPathIndex = devicesList.findIndex(item => item.path === this._devicePath);
+        if (existingPathIndex === -1)
+            return;
+
+        this._settingsItems = devicesList[existingPathIndex];
+
+        const icon = this._settingsItems.icon;
+        if (this._commonIcon !== icon) {
+            this._commonIcon = icon;
+            this._updateIcons();
+        }
+
+        const volumeEq = this._settingsItems['volume-eq'];
+        if (this._volumeEq !== volumeEq) {
+            this._volumeEq = volumeEq;
+            this._googleBudsSocket?.setVolumeEqEnable(volumeEq);
+        }
+
+        this._eqPreset = this._settingsItems['eq-preset'];
+        this._eqLastSaved = this._settingsItems['eq-last-saved'];
+
+        const eqCustom = this._settingsItems['eq-custom'];
+        if (JSON.stringify(this._eqCustom) !== JSON.stringify(eqCustom)) {
+            this._eqCustom = eqCustom;
+            this._googleBudsSocket?.setEq(eqCustom);
+        }
+    }
+
+    _updateGsettings() {
+        if (!this._settingsItems)
+            return;
+
+        this._monitorGoogleBudsListGsettings(false);
+
+        const currentList = this._settings.get_strv('google-buds-list').map(JSON.parse);
+        const index = currentList.findIndex(d => d.path === this._devicePath);
+
+        if (index !== -1) {
+            currentList[index] = this._settingsItems;
+            this._settings.set_strv('google-buds-list', currentList.map(JSON.stringify));
+        }
+
+        this._monitorGoogleBudsListGsettings(true);
+    }
+
+    _updateAncConfig(enabledModes = {off: true, aware: true, active: true, adaptive: false}) {
+        this._config.toggle1Title = _('Noise Control');
+
+        for (let i = 1; i <= 4; i++) {
+            this._config[`toggle1Button${i}Icon`] = null;
+            this._config[`toggle1Button${i}Name`] = '';
+        }
+
+        const modes = [
+            {
+                enabled: enabledModes.off,
+                state: AncState.OFF,
+                icon: 'bbm-anc-off-symbolic.svg',
+                name: _('Off'),
+            },
+            {
+                enabled: enabledModes.aware,
+                state: AncState.AWARE,
+                icon: 'bbm-transperancy-symbolic.svg',
+                name: _('Transparency'),
+            },
+            {
+                enabled: enabledModes.active,
+                state: AncState.ACTIVE,
+                icon: 'bbm-anc-on-symbolic.svg',
+                name: _('Noise Cancellation'),
+            },
+            {
+                enabled: enabledModes.adaptive,
+                state: AncState.ADAPTIVE,
+                icon: 'bbm-adaptive-symbolic.svg',
+                name: _('Adaptive'),
+            },
+        ];
+
+        this._toggle1ButtonToAncState = {};
+        let button = 1;
+
+        for (const mode of modes) {
+            if (!mode.enabled)
+                continue;
+
+            this._config[`toggle1Button${button}Icon`] = mode.icon;
+            this._config[`toggle1Button${button}Name`] = mode.name;
+            this._toggle1ButtonToAncState[button] = mode.state;
+            button++;
+        }
+
+        this._ancStateToToggle1Button = Object.fromEntries(
+            Object.entries(this._toggle1ButtonToAncState)
+                .map(([button, state]) => [state, Number(button)])
+        );
+
+        if (this._props.toggle1State &&
+                !this._toggle1ButtonToAncState[this._props.toggle1State]) {
+            this._props.toggle1State = 0;
+        }
+
+        this.dataHandler?.setConfig(this._config);
+    }
+
+    updateAncGestureLoop(gestureLoop) {
+        const enabledModes = {
+            off: true,
+            aware: true,
+            active: true,
+            adaptive: gestureLoop.adaptive,
+        };
+        this._updateAncConfig(enabledModes);
+    }
+
+    _startConfiguration(battInfo) {
+        const bat1level = battInfo.battery1Level  ?? 0;
+        const bat2level = battInfo.battery2Level  ?? 0;
+        const bat3level = battInfo.battery3Level  ?? 0;
+
+        if (bat1level <= 0 && bat2level <= 0 && bat3level <= 0)
+            return;
+
+        this._battInfoRecieved = true;
+        this._props.toggle1Visible = true;
+        this.dataHandler = new DataHandler(this._config, this._props);
+        this.updateDeviceMapCb(this._devicePath, this.dataHandler);
+        this._dataHandlerId = this.dataHandler.connect(
+            'ui-action', (o, command, value) => {
+                if (command === 'toggle1State')
+                    this._toggle1ButtonClicked(value);
+
+                if (command === 'settingsButtonClicked')
+                    this._settingsButtonClicked();
+            }
+        );
+    }
+
+    updateBatteryProps(props) {
+        this._props = {...this._props, ...props};
+        this._props.computedBatteryLevel = buds2to1BatteryLevel(this._props);
+
+        if (!this._battInfoRecieved)
+            this._startConfiguration(this._props);
+
+        this.dataHandler?.setProps(this._props);
+    }
+
+    updateAncState(ancState) {
+        const toggleState = this._ancStateToToggle1Button?.[ancState] ?? 0;
+        this._props.toggle1State = toggleState;
+        this.dataHandler?.setProps(this._props);
+    }
+
+    updateVolumeEqEnable(enabled) {
+        if (this._volumeEq === enabled)
+            return;
+
+        this._volumeEq = enabled;
+
+        if (this._settingsItems) {
+            this._settingsItems['volume-eq'] = enabled;
+            this._updateGsettings();
+        }
+    }
+
+    updateEq(eqBands) {
+        const roundedBands = eqBands.map(value => Math.round(value));
+        const preset = this._eqPresetForBands(roundedBands);
+        if (this._eqPreset === preset &&
+                JSON.stringify(this._eqCustom) === JSON.stringify(roundedBands))
+            return;
+
+        this._eqPreset = preset;
+        this._eqCustom = roundedBands;
+
+        if (this._settingsItems) {
+            this._settingsItems['eq-preset'] = preset;
+            this._settingsItems['eq-custom'] = roundedBands;
+            this._updateGsettings();
+        }
+    }
+
+    updateLastSavedEq(eqBands) {
+        const roundedBands = eqBands.map(value => Math.round(value));
+        const lastSavedChanged =
+            JSON.stringify(this._eqLastSaved) !== JSON.stringify(roundedBands);
+
+        this._eqLastSaved = roundedBands;
+        const preset = this._eqPresetForBands(this._eqCustom);
+
+        if (!lastSavedChanged && this._eqPreset === preset)
+            return;
+
+        this._eqPreset = preset;
+
+        if (this._settingsItems) {
+            this._settingsItems['eq-last-saved'] = roundedBands;
+            this._settingsItems['eq-preset'] = preset;
+            this._updateGsettings();
+        }
+    }
+
+    _eqPresetForBands(eqBands) {
+        const staticPreset = eqPresetForBands(eqBands);
+        if (staticPreset !== EqPreset.CUSTOM)
+            return staticPreset;
+
+        if (JSON.stringify(eqBands) === JSON.stringify(this._eqLastSaved))
+            return EqPreset.LAST_SAVED;
+
+        return EqPreset.CUSTOM;
+    }
+
+    _toggle1ButtonClicked(index) {
+        const ancState = this._toggle1ButtonToAncState?.[index];
+        if (!ancState)
+            return;
+
+        this._props.toggle1State = index;
+        this.dataHandler?.setProps(this._props);
+        this._googleBudsSocket?.setAncState(ancState);
+    }
+
+    _settingsButtonClicked() {
+        this._configureWindowLauncherCancellable = new Gio.Cancellable();
+        launchConfigureWindow(this._devicePath, DeviceTypeGoogleBuds, this._extPath,
+            this._configureWindowLauncherCancellable);
+        this._configureWindowLauncherCancellable = null;
+    }
+
+    destroy() {
+        this._configureWindowLauncherCancellable?.cancel();
+        this._configureWindowLauncherCancellable = null;
+
+        if (this._dataHandlerId && this.dataHandler)
+            this.dataHandler.disconnect(this._dataHandlerId);
+        this._dataHandlerId = null;
+        this._monitorGoogleBudsListGsettings(false);
+        this._googleBudsSocket?.destroy();
+        this._googleBudsSocket = null;
+        this.dataHandler = null;
+    }
+});

--- a/src/lib/devices/googleBuds/googleBudsProtocol.js
+++ b/src/lib/devices/googleBuds/googleBudsProtocol.js
@@ -1,0 +1,489 @@
+'use strict';
+
+import {addressForChannel} from './googleBudsConfig.js';
+
+const FRAME = 0x7e;
+const ESCAPE = 0x7d;
+const ESCAPE_MASK = 0x20;
+const CONTROL = 0x03;
+
+const CRC32_TABLE = (() => {
+    const table = [];
+    for (let i = 0; i < 256; i++) {
+        let crc = i;
+        for (let j = 0; j < 8; j++)
+            crc = crc & 1 ? 0xedb88320 ^ crc >>> 1 : crc >>> 1;
+        table.push(crc >>> 0);
+    }
+    return table;
+})();
+
+export class HdlcCodec {
+    constructor() {
+        this._buffer = [];
+        this._inFrame = false;
+        this._escaped = false;
+    }
+
+    decode(bytes) {
+        const frames = [];
+
+        for (const byte of bytes) {
+            if (!this._inFrame) {
+                if (byte === FRAME) {
+                    this._inFrame = true;
+                    this._buffer = [];
+                    this._escaped = false;
+                }
+                continue;
+            }
+
+            if (byte === FRAME) {
+                const frame = this._decodeBuffered();
+                if (frame)
+                    frames.push(frame);
+                this._buffer = [];
+                this._escaped = false;
+                this._inFrame = true;
+                continue;
+            }
+
+            if (this._escaped) {
+                this._buffer.push(byte ^ ESCAPE_MASK);
+                this._escaped = false;
+                continue;
+            }
+
+            if (byte === ESCAPE) {
+                this._escaped = true;
+                continue;
+            }
+
+            this._buffer.push(byte);
+        }
+
+        return frames;
+    }
+
+    encode(channel, data) {
+        const address = addressForChannel(channel);
+        if (address === null)
+            return null;
+
+        const payload = [
+            ...encodeAddress(address),
+            CONTROL,
+            ...data,
+        ];
+        const crc = crc32(payload);
+        payload.push(crc & 0xff, crc >>> 8 & 0xff, crc >>> 16 & 0xff, crc >>> 24 & 0xff);
+
+        const out = [FRAME];
+        for (const byte of payload) {
+            if (byte === FRAME || byte === ESCAPE)
+                out.push(ESCAPE, byte ^ ESCAPE_MASK);
+            else
+                out.push(byte);
+        }
+        out.push(FRAME);
+
+        return Uint8Array.from(out);
+    }
+
+    _decodeBuffered() {
+        if (this._buffer.length < 6)
+            return null;
+
+        const body = this._buffer.slice(0, -4);
+        const expected = this._buffer.at(-4) |
+            this._buffer.at(-3) << 8 |
+            this._buffer.at(-2) << 16 |
+            this._buffer.at(-1) << 24;
+        if ((crc32(body) | 0) !== (expected | 0))
+            return null;
+
+        const [address, offset] = decodeAddress(body, 0);
+        if (address === null || body[offset] !== CONTROL)
+            return null;
+
+        return {
+            address,
+            data: body.slice(offset + 1),
+        };
+    }
+}
+
+export function encodeRpcPacket(packet) {
+    const out = [];
+    writeVarintField(out, 1, packet.type);
+    writeVarintField(out, 2, packet.channelId);
+    writeFixed32Field(out, 3, packet.serviceId);
+    writeFixed32Field(out, 4, packet.methodId);
+    writeBytesField(out, 5, packet.payload ?? []);
+    writeVarintField(out, 6, packet.status ?? 0);
+    writeVarintField(out, 7, packet.callId);
+    return out;
+}
+
+export function decodeRpcPacket(bytes) {
+    const packet = {
+        type: 0,
+        channelId: 0,
+        serviceId: 0,
+        methodId: 0,
+        payload: [],
+        status: 0,
+        callId: 0,
+    };
+
+    for (const field of readFields(bytes)) {
+        switch (field.number) {
+            case 1:
+                packet.type = readVarintValue(field);
+                break;
+            case 2:
+                packet.channelId = readVarintValue(field);
+                break;
+            case 3:
+                packet.serviceId = readFixed32Value(field);
+                break;
+            case 4:
+                packet.methodId = readFixed32Value(field);
+                break;
+            case 5:
+                packet.payload = field.value;
+                break;
+            case 6:
+                packet.status = readVarintValue(field);
+                break;
+            case 7:
+                packet.callId = readVarintValue(field);
+                break;
+        }
+    }
+
+    return packet;
+}
+
+export function decodeRuntimeInfo(bytes) {
+    const props = {};
+
+    const runtimeFields = readFields(bytes);
+    const batteryField = runtimeFields.find(field => field.number === 6 && field.wireType === 2);
+    if (!batteryField)
+        return props;
+
+    for (const field of readFields(batteryField.value)) {
+        if (field.wireType !== 2)
+            continue;
+
+        const battery = decodeDeviceBatteryInfo(field.value);
+        if (!battery)
+            continue;
+
+        const index = batteryFieldToIndex(field.number);
+        if (!index)
+            continue;
+
+        props[`battery${index}Level`] = battery.level;
+        props[`battery${index}Status`] = battery.status;
+    }
+
+    return props;
+}
+
+export function encodeReadSettingPayload(settingId) {
+    const out = [];
+    writeVarintField(out, 4, settingId);
+    return out;
+}
+
+export function encodeWriteAncStatePayload(ancState) {
+    const setting = [];
+    writeVarintField(setting, 13, ancState);
+
+    const out = [];
+    writeBytesField(out, 4, setting);
+    return out;
+}
+
+export function encodeWriteVolumeEqEnablePayload(enabled) {
+    const setting = [];
+    writeVarintField(setting, 15, enabled ? 1 : 0);
+
+    const out = [];
+    writeBytesField(out, 4, setting);
+    return out;
+}
+
+export function encodeWriteEqPayload(eqBands) {
+    const eq = [];
+    for (let i = 0; i < 5; i++)
+        writeFloatField(eq, i + 1, eqBands[i] ?? 0);
+
+    const setting = [];
+    writeBytesField(setting, 16, eq);
+
+    const out = [];
+    writeBytesField(out, 4, setting);
+    return out;
+}
+
+export function decodeAncStateSettingsResponse(bytes) {
+    const settingsRsp = readFields(bytes);
+    const valueField = settingsRsp.find(field => field.number === 4 && field.wireType === 2);
+    if (!valueField)
+        return null;
+
+    const settingValue = readFields(valueField.value);
+    const ancField = settingValue.find(field => field.number === 13 && field.wireType === 0);
+    if (!ancField)
+        return null;
+
+    return readVarintValue(ancField);
+}
+
+export function decodeAncGestureLoopSettingsResponse(bytes) {
+    const settingsRsp = readFields(bytes);
+    const valueField = settingsRsp.find(field => field.number === 4 && field.wireType === 2);
+    if (!valueField)
+        return null;
+
+    const settingValue = readFields(valueField.value);
+    const gestureLoopField = settingValue.find(field => field.number === 12 && field.wireType === 2);
+    if (!gestureLoopField)
+        return null;
+
+    const loop = {
+        active: false,
+        off: false,
+        aware: false,
+        adaptive: false,
+    };
+
+    for (const field of readFields(gestureLoopField.value)) {
+        if (field.wireType !== 0)
+            continue;
+
+        const enabled = readVarintValue(field) !== 0;
+        if (field.number === 1)
+            loop.active = enabled;
+        else if (field.number === 2)
+            loop.off = enabled;
+        else if (field.number === 3)
+            loop.aware = enabled;
+        else if (field.number === 4)
+            loop.adaptive = enabled;
+    }
+
+    return loop;
+}
+
+export function decodeVolumeEqEnableSettingsResponse(bytes) {
+    const settingsRsp = readFields(bytes);
+    const valueField = settingsRsp.find(field => field.number === 4 && field.wireType === 2);
+    if (!valueField)
+        return null;
+
+    const settingValue = readFields(valueField.value);
+    const volumeEqField = settingValue.find(field => field.number === 15 && field.wireType === 0);
+    if (!volumeEqField)
+        return null;
+
+    return readVarintValue(volumeEqField) !== 0;
+}
+
+export function decodeEqSettingsResponse(bytes, fieldNumber = 16) {
+    const settingsRsp = readFields(bytes);
+    const valueField = settingsRsp.find(field => field.number === 4 && field.wireType === 2);
+    if (!valueField)
+        return null;
+
+    const settingValue = readFields(valueField.value);
+    const eqField = settingValue.find(field => field.number === fieldNumber && field.wireType === 2);
+    if (!eqField)
+        return null;
+
+    const bands = [0, 0, 0, 0, 0];
+    for (const field of readFields(eqField.value)) {
+        if (field.wireType !== 5 || field.number < 1 || field.number > 5)
+            continue;
+
+        bands[field.number - 1] = readFloatValue(field);
+    }
+
+    return bands.map(value => Math.max(-6, Math.min(6, value)));
+}
+
+function decodeDeviceBatteryInfo(bytes) {
+    let level = null;
+    let state = null;
+
+    for (const field of readFields(bytes)) {
+        if (field.number === 1)
+            level = readVarintValue(field);
+        else if (field.number === 2)
+            state = readVarintValue(field);
+    }
+
+    if (level === null)
+        return null;
+
+    return {
+        level: Math.max(0, Math.min(level, 100)),
+        status: state === 2 ? 'charging' : 'discharging',
+    };
+}
+
+function batteryFieldToIndex(fieldNumber) {
+    switch (fieldNumber) {
+        case 2:
+            return 1;
+        case 3:
+            return 2;
+        case 1:
+            return 3;
+        default:
+            return 0;
+    }
+}
+
+function readFields(bytes) {
+    const fields = [];
+    let offset = 0;
+
+    while (offset < bytes.length) {
+        const [key, keyOffset] = decodeVarint(bytes, offset);
+        if (key === null)
+            break;
+
+        offset = keyOffset;
+        const number = key >>> 3;
+        const wireType = key & 0x07;
+        let value;
+
+        if (wireType === 0) {
+            const [val, next] = decodeVarint(bytes, offset);
+            if (val === null)
+                break;
+            value = val;
+            offset = next;
+        } else if (wireType === 2) {
+            const [len, next] = decodeVarint(bytes, offset);
+            if (len === null || next + len > bytes.length)
+                break;
+            value = bytes.slice(next, next + len);
+            offset = next + len;
+        } else if (wireType === 5) {
+            if (offset + 4 > bytes.length)
+                break;
+            value = bytes.slice(offset, offset + 4);
+            offset += 4;
+        } else {
+            break;
+        }
+
+        fields.push({number, wireType, value});
+    }
+
+    return fields;
+}
+
+function readVarintValue(field) {
+    return field.wireType === 0 ? field.value : null;
+}
+
+function readFixed32Value(field) {
+    if (field.wireType !== 5 || field.value.length !== 4)
+        return null;
+    return (field.value[0] |
+        field.value[1] << 8 |
+        field.value[2] << 16 |
+        field.value[3] << 24) >>> 0;
+}
+
+function readFloatValue(field) {
+    if (field.wireType !== 5 || field.value.length !== 4)
+        return null;
+
+    const array = Uint8Array.from(field.value);
+    return new DataView(array.buffer).getFloat32(0, true);
+}
+
+function writeVarintField(out, number, value) {
+    out.push(...encodeVarint(number << 3), ...encodeVarint(value));
+}
+
+function writeFixed32Field(out, number, value) {
+    out.push(...encodeVarint(number << 3 | 5), value & 0xff, value >>> 8 & 0xff,
+        value >>> 16 & 0xff, value >>> 24 & 0xff);
+}
+
+function writeFloatField(out, number, value) {
+    const buffer = new ArrayBuffer(4);
+    new DataView(buffer).setFloat32(0, Math.max(-6, Math.min(6, value)), true);
+    out.push(...encodeVarint(number << 3 | 5), ...new Uint8Array(buffer));
+}
+
+function writeBytesField(out, number, bytes) {
+    out.push(...encodeVarint(number << 3 | 2), ...encodeVarint(bytes.length), ...bytes);
+}
+
+function encodeVarint(value) {
+    let val = value >>> 0;
+    const out = [];
+    while (val >= 0x80) {
+        out.push(val & 0x7f | 0x80);
+        val >>>= 7;
+    }
+    out.push(val);
+    return out;
+}
+
+function encodeAddress(value) {
+    let val = value >>> 0;
+    const out = [];
+    while ((val >>> 7) !== 0) {
+        out.push((val & 0x7f) << 1);
+        val >>>= 7;
+    }
+    out.push((val & 0x7f) << 1 | 1);
+    return out;
+}
+
+function decodeVarint(bytes, offset) {
+    let value = 0;
+    let shift = 0;
+
+    for (let i = offset; i < bytes.length && shift < 64; i++) {
+        const byte = bytes[i];
+        value += (byte & 0x7f) * 2 ** shift;
+        if ((byte & 0x80) === 0)
+            return [value, i + 1];
+        shift += 7;
+    }
+
+    return [null, offset];
+}
+
+function decodeAddress(bytes, offset) {
+    let value = 0;
+    let shift = 0;
+
+    for (let i = offset; i < bytes.length && shift < 35; i++) {
+        const byte = bytes[i];
+        value |= (byte >>> 1) << shift;
+        if ((byte & 0x01) === 0x01)
+            return [value >>> 0, i + 1];
+        shift += 7;
+    }
+
+    return [null, offset];
+}
+
+function crc32(bytes) {
+    let crc = 0xffffffff;
+    for (const byte of bytes)
+        crc = CRC32_TABLE[(crc ^ byte) & 0xff] ^ crc >>> 8;
+    return (crc ^ 0xffffffff) >>> 0;
+}

--- a/src/lib/devices/googleBuds/googleBudsSocket.js
+++ b/src/lib/devices/googleBuds/googleBudsSocket.js
@@ -1,4 +1,5 @@
 'use strict';
+import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 
 import {createLogger} from '../logger.js';
@@ -22,6 +23,8 @@ const READ_VOLUME_EQ_CALL_ID = 5;
 const READ_EQ_CALL_ID = 6;
 const READ_LAST_SAVED_EQ_CALL_ID = 7;
 const WRITE_SETTING_CALL_ID_BASE = 100;
+const WRITE_RESPONSE_TIMEOUT_MS = 3000;
+const WRITE_REFRESH_TIMEOUT_MS = 3000;
 
 export const GoogleBudsSocket = GObject.registerClass({
     GTypeName: 'BudsLink_GoogleBudsSocket',
@@ -42,6 +45,9 @@ export const GoogleBudsSocket = GObject.registerClass({
         this._writeQueue = [];
         this._writeInFlight = false;
         this._resumeWritesAfterReadCallId = null;
+        this._resumeWritesAfterReadSetting = null;
+        this._writeResponseTimeoutId = 0;
+        this._writeRefreshTimeoutId = 0;
 
         this.startSocket();
     }
@@ -88,6 +94,15 @@ export const GoogleBudsSocket = GObject.registerClass({
                 packet.channelId === this._channel &&
                 packet.serviceId === MaestroService &&
                 packet.methodId === MaestroMethod.READ_SETTING &&
+                packet.callId === this._resumeWritesAfterReadCallId) {
+            this._processWriteRefreshResponse(packet);
+            return;
+        }
+
+        if (this._channel !== null && packet.type === PacketType.RESPONSE &&
+                packet.channelId === this._channel &&
+                packet.serviceId === MaestroService &&
+                packet.methodId === MaestroMethod.READ_SETTING &&
                 packet.callId === READ_ANC_STATE_CALL_ID) {
             if (packet.status === Status.OK) {
                 const ancState = decodeAncStateSettingsResponse(packet.payload);
@@ -95,8 +110,7 @@ export const GoogleBudsSocket = GObject.registerClass({
                     this._callbacks?.updateAncState?.(ancState);
             }
             if (this._resumeWritesAfterReadCallId === READ_ANC_STATE_CALL_ID) {
-                this._resumeWritesAfterReadCallId = null;
-                this._sendNextWriteSetting();
+                this._completeWriteRefresh();
                 return;
             }
             this.readVolumeEqEnable();
@@ -128,8 +142,7 @@ export const GoogleBudsSocket = GObject.registerClass({
                     this._callbacks?.updateVolumeEqEnable?.(enabled);
             }
             if (this._resumeWritesAfterReadCallId === READ_VOLUME_EQ_CALL_ID) {
-                this._resumeWritesAfterReadCallId = null;
-                this._sendNextWriteSetting();
+                this._completeWriteRefresh();
                 return;
             }
             this.readEq();
@@ -147,8 +160,7 @@ export const GoogleBudsSocket = GObject.registerClass({
                     this._callbacks?.updateEq?.(eq);
             }
             if (this._resumeWritesAfterReadCallId === READ_EQ_CALL_ID) {
-                this._resumeWritesAfterReadCallId = null;
-                this._sendNextWriteSetting();
+                this._completeWriteRefresh();
                 return;
             }
             this.readLastSavedEq();
@@ -291,14 +303,18 @@ export const GoogleBudsSocket = GObject.registerClass({
         if (this._channel === null)
             return;
 
+        this._readSetting(SettingId.LAST_SAVED_USER_EQ, READ_LAST_SAVED_EQ_CALL_ID);
+    }
+
+    _readSetting(settingId, callId) {
         this._sendRpcPacket({
             type: PacketType.REQUEST,
             channelId: this._channel,
             serviceId: MaestroService,
             methodId: MaestroMethod.READ_SETTING,
-            payload: encodeReadSettingPayload(SettingId.LAST_SAVED_USER_EQ),
+            payload: encodeReadSettingPayload(settingId),
             status: Status.OK,
-            callId: READ_LAST_SAVED_EQ_CALL_ID,
+            callId,
         });
     }
 
@@ -329,13 +345,16 @@ export const GoogleBudsSocket = GObject.registerClass({
     }
 
     _sendNextWriteSetting() {
-        if (this._writeInFlight || this._writeQueue.length === 0 || this._channel === null)
+        if (this._writeInFlight || this._resumeWritesAfterReadCallId !== null ||
+                this._writeQueue.length === 0 || this._channel === null) {
             return;
+        }
 
         const {setting, payload} = this._writeQueue.shift();
         this._writeCallId++;
         this._pendingWriteSettings.set(this._writeCallId, setting);
         this._writeInFlight = true;
+        this._startWriteResponseTimeout(this._writeCallId, setting);
         this._sendRpcPacket({
             type: PacketType.REQUEST,
             channelId: this._channel,
@@ -348,25 +367,115 @@ export const GoogleBudsSocket = GObject.registerClass({
     }
 
     _refreshWrittenSetting(callId) {
+        if (!this._pendingWriteSettings.has(callId)) {
+            this._log.info(`Ignoring stale Maestro setting write response callId=${callId}`);
+            return;
+        }
+
+        this._clearWriteResponseTimeout();
         const setting = this._pendingWriteSettings.get(callId);
         this._pendingWriteSettings.delete(callId);
         this._writeInFlight = false;
 
-        if (setting === 'anc')
-            this._resumeWritesAfterReadCallId = READ_ANC_STATE_CALL_ID;
-        else if (setting === 'volumeEq')
-            this._resumeWritesAfterReadCallId = READ_VOLUME_EQ_CALL_ID;
-        else if (setting === 'eq')
-            this._resumeWritesAfterReadCallId = READ_EQ_CALL_ID;
+        this._resumeWritesAfterReadCallId = ++this._writeCallId;
+        this._resumeWritesAfterReadSetting = setting;
 
-        if (setting === 'anc')
-            this.readAncState();
-        else if (setting === 'volumeEq')
-            this.readVolumeEqEnable();
-        else if (setting === 'eq')
-            this.readEq();
-        else
+        if (setting === 'anc') {
+            this._startWriteRefreshTimeout(this._resumeWritesAfterReadCallId, setting);
+            this._readSetting(SettingId.CURRENT_ANCR_STATE, this._resumeWritesAfterReadCallId);
+        } else if (setting === 'volumeEq') {
+            this._startWriteRefreshTimeout(this._resumeWritesAfterReadCallId, setting);
+            this._readSetting(SettingId.VOLUME_EQ_ENABLE, this._resumeWritesAfterReadCallId);
+        } else if (setting === 'eq') {
+            this._startWriteRefreshTimeout(this._resumeWritesAfterReadCallId, setting);
+            this._readSetting(SettingId.CURRENT_USER_EQ, this._resumeWritesAfterReadCallId);
+        } else {
+            this._resumeWritesAfterReadCallId = null;
+            this._resumeWritesAfterReadSetting = null;
             this._sendNextWriteSetting();
+        }
+    }
+
+    _startWriteResponseTimeout(callId, setting) {
+        this._clearWriteResponseTimeout();
+        this._writeResponseTimeoutId = GLib.timeout_add(
+            GLib.PRIORITY_DEFAULT,
+            WRITE_RESPONSE_TIMEOUT_MS,
+            () => {
+                this._writeResponseTimeoutId = 0;
+                if (!this._pendingWriteSettings.has(callId))
+                    return GLib.SOURCE_REMOVE;
+
+                this._pendingWriteSettings.delete(callId);
+                this._writeInFlight = false;
+                this._log.info(
+                    `Maestro setting write timed out setting=${setting} callId=${callId}`
+                );
+                this._sendNextWriteSetting();
+                return GLib.SOURCE_REMOVE;
+            }
+        );
+    }
+
+    _clearWriteResponseTimeout() {
+        if (this._writeResponseTimeoutId) {
+            GLib.Source.remove(this._writeResponseTimeoutId);
+            this._writeResponseTimeoutId = 0;
+        }
+    }
+
+    _startWriteRefreshTimeout(readCallId, setting) {
+        this._clearWriteRefreshTimeout();
+        this._writeRefreshTimeoutId = GLib.timeout_add(
+            GLib.PRIORITY_DEFAULT,
+            WRITE_REFRESH_TIMEOUT_MS,
+            () => {
+                this._writeRefreshTimeoutId = 0;
+                if (this._resumeWritesAfterReadCallId !== readCallId)
+                    return GLib.SOURCE_REMOVE;
+
+                this._resumeWritesAfterReadCallId = null;
+                this._resumeWritesAfterReadSetting = null;
+                this._log.info(
+                    `Maestro setting refresh timed out setting=${setting} callId=${readCallId}`
+                );
+                this._sendNextWriteSetting();
+                return GLib.SOURCE_REMOVE;
+            }
+        );
+    }
+
+    _clearWriteRefreshTimeout() {
+        if (this._writeRefreshTimeoutId) {
+            GLib.Source.remove(this._writeRefreshTimeoutId);
+            this._writeRefreshTimeoutId = 0;
+        }
+    }
+
+    _completeWriteRefresh() {
+        this._clearWriteRefreshTimeout();
+        this._resumeWritesAfterReadCallId = null;
+        this._resumeWritesAfterReadSetting = null;
+        this._sendNextWriteSetting();
+    }
+
+    _processWriteRefreshResponse(packet) {
+        if (packet.status === Status.OK) {
+            if (this._resumeWritesAfterReadSetting === 'anc') {
+                const ancState = decodeAncStateSettingsResponse(packet.payload);
+                if (ancState !== null)
+                    this._callbacks?.updateAncState?.(ancState);
+            } else if (this._resumeWritesAfterReadSetting === 'volumeEq') {
+                const enabled = decodeVolumeEqEnableSettingsResponse(packet.payload);
+                if (enabled !== null)
+                    this._callbacks?.updateVolumeEqEnable?.(enabled);
+            } else if (this._resumeWritesAfterReadSetting === 'eq') {
+                const eq = decodeEqSettingsResponse(packet.payload);
+                if (eq !== null)
+                    this._callbacks?.updateEq?.(eq);
+            }
+        }
+        this._completeWriteRefresh();
     }
 
     _processSettingsPayload(payload) {
@@ -400,5 +509,13 @@ export const GoogleBudsSocket = GObject.registerClass({
         const frame = this._codec.encode(packet.channelId, bytes);
         if (frame)
             this.sendMessage(frame);
+    }
+
+    destroy() {
+        this._clearWriteResponseTimeout();
+        this._clearWriteRefreshTimeout();
+        this._writeQueue = [];
+        this._pendingWriteSettings.clear();
+        super.destroy();
     }
 });

--- a/src/lib/devices/googleBuds/googleBudsSocket.js
+++ b/src/lib/devices/googleBuds/googleBudsSocket.js
@@ -1,0 +1,404 @@
+'use strict';
+import GObject from 'gi://GObject';
+
+import {createLogger} from '../logger.js';
+import {SocketHandler} from '../socketByProfile.js';
+import {
+    CandidateChannels, MaestroMethod, MaestroService, PacketType, SettingId, Status
+} from './googleBudsConfig.js';
+import {
+    HdlcCodec, decodeAncGestureLoopSettingsResponse, decodeAncStateSettingsResponse,
+    decodeEqSettingsResponse, decodeRpcPacket, decodeRuntimeInfo,
+    decodeVolumeEqEnableSettingsResponse, encodeReadSettingPayload, encodeRpcPacket,
+    encodeWriteAncStatePayload, encodeWriteEqPayload, encodeWriteVolumeEqEnablePayload
+} from './googleBudsProtocol.js';
+
+const SOFTWARE_INFO_CALL_ID = 0xffffffff;
+const RUNTIME_INFO_CALL_ID = 1;
+const READ_ANC_STATE_CALL_ID = 2;
+const READ_ANC_GESTURE_LOOP_CALL_ID = 3;
+const SETTINGS_CHANGES_CALL_ID = 4;
+const READ_VOLUME_EQ_CALL_ID = 5;
+const READ_EQ_CALL_ID = 6;
+const READ_LAST_SAVED_EQ_CALL_ID = 7;
+const WRITE_SETTING_CALL_ID_BASE = 100;
+
+export const GoogleBudsSocket = GObject.registerClass({
+    GTypeName: 'BudsLink_GoogleBudsSocket',
+}, class GoogleBudsSocket extends SocketHandler {
+    _init(devicePath, profileManager, profile, callbacks) {
+        super._init(devicePath, profileManager, profile);
+        const identifier = devicePath.slice(-2);
+        const tag = `GoogleBudsSocket-${identifier}`;
+        this._log = createLogger(tag);
+        this._log.info('GoogleBudsSocket init');
+
+        this._codec = new HdlcCodec();
+        this._callbacks = callbacks;
+        this._channel = null;
+        this._writeCallId = WRITE_SETTING_CALL_ID_BASE;
+        this._ancReadAfterRuntime = false;
+        this._pendingWriteSettings = new Map();
+        this._writeQueue = [];
+        this._writeInFlight = false;
+        this._resumeWritesAfterReadCallId = null;
+
+        this.startSocket();
+    }
+
+    postConnectInitialization() {
+        this._log.info('Waiting for Maestro software-info response');
+    }
+
+    processData(bytes) {
+        for (const frame of this._codec.decode(bytes)) {
+            try {
+                this._processPacket(decodeRpcPacket(frame.data));
+            } catch (e) {
+                this._log.error(e, 'Failed to decode Maestro packet');
+            }
+        }
+    }
+
+    _processPacket(packet) {
+        if (this._channel === null && this._isSoftwareInfoResponse(packet)) {
+            this._channel = packet.channelId;
+            this._log.info(`Resolved Maestro channel ${this._channel}`);
+            this._subscribeRuntimeInfo();
+            this._subscribeSettingsChanges();
+            return;
+        }
+
+        if (this._channel !== null && packet.type === PacketType.SERVER_STREAM &&
+                packet.channelId === this._channel &&
+                packet.serviceId === MaestroService &&
+                packet.methodId === MaestroMethod.SUBSCRIBE_RUNTIME_INFO &&
+                packet.callId === RUNTIME_INFO_CALL_ID) {
+            const props = decodeRuntimeInfo(packet.payload);
+            if (Object.keys(props).length > 0)
+                this._callbacks?.updateBatteryProps?.(props);
+            if (!this._ancReadAfterRuntime) {
+                this._ancReadAfterRuntime = true;
+                this.readAncGestureLoop();
+            }
+            return;
+        }
+
+        if (this._channel !== null && packet.type === PacketType.RESPONSE &&
+                packet.channelId === this._channel &&
+                packet.serviceId === MaestroService &&
+                packet.methodId === MaestroMethod.READ_SETTING &&
+                packet.callId === READ_ANC_STATE_CALL_ID) {
+            if (packet.status === Status.OK) {
+                const ancState = decodeAncStateSettingsResponse(packet.payload);
+                if (ancState !== null)
+                    this._callbacks?.updateAncState?.(ancState);
+            }
+            if (this._resumeWritesAfterReadCallId === READ_ANC_STATE_CALL_ID) {
+                this._resumeWritesAfterReadCallId = null;
+                this._sendNextWriteSetting();
+                return;
+            }
+            this.readVolumeEqEnable();
+            return;
+        }
+
+        if (this._channel !== null && packet.type === PacketType.RESPONSE &&
+                packet.channelId === this._channel &&
+                packet.serviceId === MaestroService &&
+                packet.methodId === MaestroMethod.READ_SETTING &&
+                packet.callId === READ_ANC_GESTURE_LOOP_CALL_ID) {
+            if (packet.status === Status.OK) {
+                const gestureLoop = decodeAncGestureLoopSettingsResponse(packet.payload);
+                if (gestureLoop !== null)
+                    this._callbacks?.updateAncGestureLoop?.(gestureLoop);
+            }
+            this.readAncState();
+            return;
+        }
+
+        if (this._channel !== null && packet.type === PacketType.RESPONSE &&
+                packet.channelId === this._channel &&
+                packet.serviceId === MaestroService &&
+                packet.methodId === MaestroMethod.READ_SETTING &&
+                packet.callId === READ_VOLUME_EQ_CALL_ID) {
+            if (packet.status === Status.OK) {
+                const enabled = decodeVolumeEqEnableSettingsResponse(packet.payload);
+                if (enabled !== null)
+                    this._callbacks?.updateVolumeEqEnable?.(enabled);
+            }
+            if (this._resumeWritesAfterReadCallId === READ_VOLUME_EQ_CALL_ID) {
+                this._resumeWritesAfterReadCallId = null;
+                this._sendNextWriteSetting();
+                return;
+            }
+            this.readEq();
+            return;
+        }
+
+        if (this._channel !== null && packet.type === PacketType.RESPONSE &&
+                packet.channelId === this._channel &&
+                packet.serviceId === MaestroService &&
+                packet.methodId === MaestroMethod.READ_SETTING &&
+                packet.callId === READ_EQ_CALL_ID) {
+            if (packet.status === Status.OK) {
+                const eq = decodeEqSettingsResponse(packet.payload);
+                if (eq !== null)
+                    this._callbacks?.updateEq?.(eq);
+            }
+            if (this._resumeWritesAfterReadCallId === READ_EQ_CALL_ID) {
+                this._resumeWritesAfterReadCallId = null;
+                this._sendNextWriteSetting();
+                return;
+            }
+            this.readLastSavedEq();
+            return;
+        }
+
+        if (this._channel !== null && packet.type === PacketType.RESPONSE &&
+                packet.channelId === this._channel &&
+                packet.serviceId === MaestroService &&
+                packet.methodId === MaestroMethod.READ_SETTING &&
+                packet.callId === READ_LAST_SAVED_EQ_CALL_ID) {
+            if (packet.status === Status.OK) {
+                const eq = decodeEqSettingsResponse(packet.payload, SettingId.LAST_SAVED_USER_EQ);
+                if (eq !== null)
+                    this._callbacks?.updateLastSavedEq?.(eq);
+            } else {
+                this._log.info(`Last saved EQ read failed with status ${packet.status}`);
+            }
+            return;
+        }
+
+        if (this._channel !== null && packet.type === PacketType.SERVER_STREAM &&
+                packet.channelId === this._channel &&
+                packet.serviceId === MaestroService &&
+                packet.methodId === MaestroMethod.SUBSCRIBE_SETTINGS_CHANGES &&
+                packet.callId === SETTINGS_CHANGES_CALL_ID) {
+            this._processSettingsPayload(packet.payload);
+            return;
+        }
+
+        if (this._channel !== null &&
+                (packet.type === PacketType.RESPONSE || packet.type === PacketType.SERVER_ERROR) &&
+                packet.channelId === this._channel &&
+                packet.serviceId === MaestroService &&
+                packet.methodId === MaestroMethod.WRITE_SETTING &&
+                packet.callId >= WRITE_SETTING_CALL_ID_BASE) {
+            if (packet.status !== Status.OK)
+                this._log.info(`Maestro setting write failed with status ${packet.status}`);
+            this._refreshWrittenSetting(packet.callId);
+            return;
+        }
+
+        if (packet.type === PacketType.SERVER_STREAM)
+            this._sendClientError(packet, Status.FAILED_PRECONDITION);
+    }
+
+    _isSoftwareInfoResponse(packet) {
+        return packet.type === PacketType.RESPONSE &&
+            CandidateChannels.includes(packet.channelId) &&
+            packet.serviceId === MaestroService &&
+            packet.methodId === MaestroMethod.GET_SOFTWARE_INFO &&
+            packet.callId === SOFTWARE_INFO_CALL_ID;
+    }
+
+    _subscribeRuntimeInfo() {
+        this._sendRpcPacket({
+            type: PacketType.REQUEST,
+            channelId: this._channel,
+            serviceId: MaestroService,
+            methodId: MaestroMethod.SUBSCRIBE_RUNTIME_INFO,
+            payload: [],
+            status: Status.OK,
+            callId: RUNTIME_INFO_CALL_ID,
+        });
+    }
+
+    _subscribeSettingsChanges() {
+        this._sendRpcPacket({
+            type: PacketType.REQUEST,
+            channelId: this._channel,
+            serviceId: MaestroService,
+            methodId: MaestroMethod.SUBSCRIBE_SETTINGS_CHANGES,
+            payload: [],
+            status: Status.OK,
+            callId: SETTINGS_CHANGES_CALL_ID,
+        });
+    }
+
+    readAncState() {
+        if (this._channel === null)
+            return;
+
+        this._sendRpcPacket({
+            type: PacketType.REQUEST,
+            channelId: this._channel,
+            serviceId: MaestroService,
+            methodId: MaestroMethod.READ_SETTING,
+            payload: encodeReadSettingPayload(SettingId.CURRENT_ANCR_STATE),
+            status: Status.OK,
+            callId: READ_ANC_STATE_CALL_ID,
+        });
+    }
+
+    readAncGestureLoop() {
+        if (this._channel === null)
+            return;
+
+        this._sendRpcPacket({
+            type: PacketType.REQUEST,
+            channelId: this._channel,
+            serviceId: MaestroService,
+            methodId: MaestroMethod.READ_SETTING,
+            payload: encodeReadSettingPayload(SettingId.ANCR_GESTURE_LOOP),
+            status: Status.OK,
+            callId: READ_ANC_GESTURE_LOOP_CALL_ID,
+        });
+    }
+
+    readVolumeEqEnable() {
+        if (this._channel === null)
+            return;
+
+        this._sendRpcPacket({
+            type: PacketType.REQUEST,
+            channelId: this._channel,
+            serviceId: MaestroService,
+            methodId: MaestroMethod.READ_SETTING,
+            payload: encodeReadSettingPayload(SettingId.VOLUME_EQ_ENABLE),
+            status: Status.OK,
+            callId: READ_VOLUME_EQ_CALL_ID,
+        });
+    }
+
+    readEq() {
+        if (this._channel === null)
+            return;
+
+        this._sendRpcPacket({
+            type: PacketType.REQUEST,
+            channelId: this._channel,
+            serviceId: MaestroService,
+            methodId: MaestroMethod.READ_SETTING,
+            payload: encodeReadSettingPayload(SettingId.CURRENT_USER_EQ),
+            status: Status.OK,
+            callId: READ_EQ_CALL_ID,
+        });
+    }
+
+    readLastSavedEq() {
+        if (this._channel === null)
+            return;
+
+        this._sendRpcPacket({
+            type: PacketType.REQUEST,
+            channelId: this._channel,
+            serviceId: MaestroService,
+            methodId: MaestroMethod.READ_SETTING,
+            payload: encodeReadSettingPayload(SettingId.LAST_SAVED_USER_EQ),
+            status: Status.OK,
+            callId: READ_LAST_SAVED_EQ_CALL_ID,
+        });
+    }
+
+    setAncState(ancState) {
+        if (this._channel === null)
+            return;
+
+        this._queueWriteSetting('anc', encodeWriteAncStatePayload(ancState));
+    }
+
+    setVolumeEqEnable(enabled) {
+        if (this._channel === null)
+            return;
+
+        this._queueWriteSetting('volumeEq', encodeWriteVolumeEqEnablePayload(enabled));
+    }
+
+    setEq(eqBands) {
+        if (this._channel === null)
+            return;
+
+        this._queueWriteSetting('eq', encodeWriteEqPayload(eqBands));
+    }
+
+    _queueWriteSetting(setting, payload) {
+        this._writeQueue.push({setting, payload});
+        this._sendNextWriteSetting();
+    }
+
+    _sendNextWriteSetting() {
+        if (this._writeInFlight || this._writeQueue.length === 0 || this._channel === null)
+            return;
+
+        const {setting, payload} = this._writeQueue.shift();
+        this._writeCallId++;
+        this._pendingWriteSettings.set(this._writeCallId, setting);
+        this._writeInFlight = true;
+        this._sendRpcPacket({
+            type: PacketType.REQUEST,
+            channelId: this._channel,
+            serviceId: MaestroService,
+            methodId: MaestroMethod.WRITE_SETTING,
+            payload,
+            status: Status.OK,
+            callId: this._writeCallId,
+        });
+    }
+
+    _refreshWrittenSetting(callId) {
+        const setting = this._pendingWriteSettings.get(callId);
+        this._pendingWriteSettings.delete(callId);
+        this._writeInFlight = false;
+
+        if (setting === 'anc')
+            this._resumeWritesAfterReadCallId = READ_ANC_STATE_CALL_ID;
+        else if (setting === 'volumeEq')
+            this._resumeWritesAfterReadCallId = READ_VOLUME_EQ_CALL_ID;
+        else if (setting === 'eq')
+            this._resumeWritesAfterReadCallId = READ_EQ_CALL_ID;
+
+        if (setting === 'anc')
+            this.readAncState();
+        else if (setting === 'volumeEq')
+            this.readVolumeEqEnable();
+        else if (setting === 'eq')
+            this.readEq();
+        else
+            this._sendNextWriteSetting();
+    }
+
+    _processSettingsPayload(payload) {
+        const ancState = decodeAncStateSettingsResponse(payload);
+        if (ancState !== null)
+            this._callbacks?.updateAncState?.(ancState);
+
+        const volumeEq = decodeVolumeEqEnableSettingsResponse(payload);
+        if (volumeEq !== null)
+            this._callbacks?.updateVolumeEqEnable?.(volumeEq);
+
+        const eq = decodeEqSettingsResponse(payload);
+        if (eq !== null)
+            this._callbacks?.updateEq?.(eq);
+    }
+
+    _sendClientError(packet, status) {
+        this._sendRpcPacket({
+            type: PacketType.CLIENT_ERROR,
+            channelId: packet.channelId,
+            serviceId: packet.serviceId,
+            methodId: packet.methodId,
+            payload: [],
+            status,
+            callId: packet.callId,
+        });
+    }
+
+    _sendRpcPacket(packet) {
+        const bytes = encodeRpcPacket(packet);
+        const frame = this._codec.encode(packet.channelId, bytes);
+        if (frame)
+            this.sendMessage(frame);
+    }
+});

--- a/src/lib/devices/logger.js
+++ b/src/lib/devices/logger.js
@@ -40,10 +40,26 @@ function enforceLogSizeLimit(logFile, historyFile) {
     }
 }
 
+function sanitizeLogMessage(msg) {
+    return msg
+        .replace(
+            /(\[[^\]]*(?:Device|Socket)[^\]]*-)[0-9A-Fa-f]{2}(\])/g,
+            '$1XX$2'
+        )
+        .replace(
+            /dev_([0-9A-Fa-f]{2}_){5}[0-9A-Fa-f]{2}/g,
+            'dev_XX_XX_XX_XX_XX_XX'
+        )
+        .replace(
+            /([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}/g,
+            'XX:XX:XX:XX:XX:XX'
+        );
+}
+
 function WriteLogLine(prefix, msg) {
     const {logFile, historyFile} = getLogFiles();
     enforceLogSizeLimit(logFile, historyFile);
-    const line = `[${new Date().toISOString()}] ${prefix}: ${msg}\n\n`;
+    const line = `[${new Date().toISOString()}] ${prefix}: ${sanitizeLogMessage(msg)}\n\n`;
 
     const stream = logFile.append_to(Gio.FileCreateFlags.NONE, null);
     const bytes = new GLib.Bytes(line);
@@ -81,4 +97,3 @@ export function initLogger(settings) {
         LOG_ENABLED = _settings.get_boolean('logging-enabled');
     });
 }
-

--- a/src/lib/enhancedDeviceSupportManager.js
+++ b/src/lib/enhancedDeviceSupportManager.js
@@ -14,6 +14,9 @@ import {
 import {
     NothingBudsDevice, isNothingBuds, DeviceTypeNothingBuds
 } from './devices/nothingBuds/nothingBudsDevice.js';
+import {
+    GoogleBudsDevice, isGoogleBuds, DeviceTypeGoogleBuds
+} from './devices/googleBuds/googleBudsDevice.js';
 
 export const EnhancedDeviceSupportManager = GObject.registerClass({
     GTypeName: 'BudsLink_EnhancedDeviceSupportManager',
@@ -93,6 +96,11 @@ export const EnhancedDeviceSupportManager = GObject.registerClass({
                     enabled: this._toggle.nothingBudsEnabled,
                     check: isNothingBuds,
                     type: DeviceTypeNothingBuds,
+                },
+                {
+                    enabled: this._toggle.googleBudsEnabled,
+                    check: isGoogleBuds,
+                    type: DeviceTypeGoogleBuds,
                 },
             ];
             /* ------------------------------------- */
@@ -176,6 +184,11 @@ export const EnhancedDeviceSupportManager = GObject.registerClass({
                 } else if (deviceProps.type === DeviceTypeNothingBuds) {
                     deviceProps.enhancedDevice =
                         new NothingBudsDevice(this._settings, path, deviceProps.alias,
+                            this._extPath, this._profileManager,
+                            this.updateDeviceMapCb.bind(this));
+                } else if (deviceProps.type === DeviceTypeGoogleBuds) {
+                    deviceProps.enhancedDevice =
+                        new GoogleBudsDevice(this._settings, path, deviceProps.alias,
                             this._extPath, this._profileManager,
                             this.updateDeviceMapCb.bind(this));
                 }

--- a/src/lib/enhancedDeviceSupportManager.js
+++ b/src/lib/enhancedDeviceSupportManager.js
@@ -2,6 +2,7 @@
 import GObject from 'gi://GObject';
 
 import {getBluezDeviceProxy} from './bluezDeviceProxy.js';
+import {createLogger} from './devices/logger.js';
 import {Notifier} from './devices/notifier.js';
 import {ProfileManager} from './devices/profileManager.js';
 import {AirpodsDevice, isAirpods, DeviceTypeAirpods} from './devices/airpods/airpodsDevice.js';
@@ -27,6 +28,7 @@ export const EnhancedDeviceSupportManager = GObject.registerClass({
         this._settings = toggle.settings;
         this._extPath = toggle.extPath;
         this._deviceMap = new Map();
+        this._log = createLogger('EnhancedDeviceSupportManager');
         this._notifier = new Notifier(toggle);
         this._profileManager = new ProfileManager(this._notifyCb.bind(this));
     }
@@ -63,7 +65,23 @@ export const EnhancedDeviceSupportManager = GObject.registerClass({
 
         if (deviceProps.pendingDetection) {
             const bluezDeviceProxy = getBluezDeviceProxy(path);
-            const uuids = bluezDeviceProxy.UUIDs;
+            const uuids = bluezDeviceProxy.UUIDs ?? [];
+            const safePath = this._safeBluezPath(path);
+            this._log.info(
+                `Detecting device path=${safePath} connected=${connected} ` +
+                `icon=${icon ?? ''} uuidCount=${uuids?.length ?? 0}`
+            );
+            this._log.info(`Device UUIDs path=${safePath}: ${uuids?.join(', ') ?? ''}`);
+
+            if (uuids.length === 0) {
+                this._log.info(`Detection pending path=${safePath} waitingFor=UUIDs`);
+                deviceProps.pendingDetection = true;
+                this._waitForBluezProps(path, bluezDeviceProxy, ['UUIDs'], deviceProps);
+                return {
+                    type: deviceProps.type, dataHandler: deviceProps.dataHandler,
+                    pendingDetection: deviceProps.pendingDetection,
+                };
+            }
 
             /* ----- Add device variant here _______ */
             const deviceModes = [
@@ -111,12 +129,17 @@ export const EnhancedDeviceSupportManager = GObject.registerClass({
                 const {supported, bluezProps} = mode.check(bluezDeviceProxy, uuids);
 
                 if (supported === 'pending') {
+                    this._log.info(
+                        `Detection pending path=${safePath} type=${mode.type} ` +
+                        `waitingFor=${bluezProps.join(',')}`
+                    );
                     deviceProps.pendingDetection = true;
                     this._waitForBluezProps(path, bluezDeviceProxy, bluezProps, deviceProps);
                     break;
                 }
 
                 if (supported === 'yes') {
+                    this._log.info(`Detected device path=${safePath} type=${mode.type}`);
                     deviceProps.type = mode.type;
                     deviceProps.pendingDetection = false;
                     break;
@@ -131,9 +154,15 @@ export const EnhancedDeviceSupportManager = GObject.registerClass({
     }
 
     _waitForBluezProps(path, bluezDeviceProxy, bluezProps, deviceProps) {
+        if (deviceProps.bluezId && deviceProps.bluezDeviceProxy)
+            return;
+
         const allPropsReady = () => {
             return bluezProps.every(prop => {
                 const value = bluezDeviceProxy[prop];
+                if (Array.isArray(value))
+                    return value.length > 0;
+
                 return value !== null && value !== undefined;
             });
         };
@@ -143,6 +172,10 @@ export const EnhancedDeviceSupportManager = GObject.registerClass({
                 return;
 
             if (allPropsReady()) {
+                this._log.info(
+                    `Pending detection properties ready path=${this._safeBluezPath(path)} ` +
+                    `props=${bluezProps.join(',')}`
+                );
                 if (this._deviceMap.has(path)) {
                     const props = this._deviceMap.get(path);
                     props.bluezDeviceProxy.disconnect(deviceProps.bluezId);
@@ -165,6 +198,10 @@ export const EnhancedDeviceSupportManager = GObject.registerClass({
     updateEnhancedDevicesInstance() {
         for (const [path, deviceProps] of this._deviceMap.entries()) {
             if (deviceProps.type && deviceProps.connected && !deviceProps.enhancedDevice) {
+                this._log.info(
+                    `Creating enhanced device path=${this._safeBluezPath(path)} ` +
+                    `type=${deviceProps.type}`
+                );
                 /* ----- Add device variant here _______ */
                 if (deviceProps.type === DeviceTypeAirpods) {
                     deviceProps.enhancedDevice =
@@ -197,6 +234,13 @@ export const EnhancedDeviceSupportManager = GObject.registerClass({
                 this._destroyEnhancedDevice(path);
             }
         }
+    }
+
+    _safeBluezPath(path) {
+        return path.replace(
+            /dev_([0-9A-Fa-f]{2}_){5}[0-9A-Fa-f]{2}/,
+            'dev_XX_XX_XX_XX_XX_XX'
+        );
     }
 
     _destroyEnhancedDevice(path) {

--- a/src/preferences/devices/googleBuds/configureWindow.js
+++ b/src/preferences/devices/googleBuds/configureWindow.js
@@ -1,0 +1,171 @@
+'use strict';
+import Adw from 'gi://Adw';
+import GObject from 'gi://GObject';
+
+import {EqualizerWidget} from './../../widgets/equalizerWidget.js';
+import {DropDownRowWidget} from './../../widgets/dropDownRowWidget.js';
+import {
+    EqPreset, EqPresetBands, eqPresetForBands
+} from '../../../lib/devices/googleBuds/googleBudsConfig.js';
+
+export const ConfigureWindow = GObject.registerClass({
+    GTypeName: 'BudsLink_GoogleBudsConfigureWindow',
+}, class ConfigureWindow extends Adw.Window {
+    _init(settings, mac, devicePath, parentWindow, _, modal = false) {
+        super._init({
+            default_width: 650,
+            default_height: 650,
+            width_request: 320,
+            height_request: 100,
+            modal,
+            transient_for: parentWindow ?? null,
+        });
+
+        this._settings = settings;
+        this._devicePath = devicePath;
+
+        const pathsString = settings.get_strv('google-buds-list').map(JSON.parse);
+        this._settingsItems = pathsString.find(info => info.path === devicePath);
+        if (!this._settingsItems)
+            return;
+
+        this.title = this._settingsItems.alias;
+
+        const toolViewBar = new Adw.ToolbarView();
+        const headerBar = new Adw.HeaderBar();
+        const page = new Adw.PreferencesPage();
+
+        toolViewBar.add_top_bar(headerBar);
+        toolViewBar.set_content(page);
+        this.set_content(toolViewBar);
+
+        const eqGroup = new Adw.PreferencesGroup({title: _('Equalizer')});
+        page.add(eqGroup);
+
+        this._volumeEqSwitch = new Adw.SwitchRow({
+            title: _('Volume EQ'),
+        });
+        this._volumeEqSwitch.active = this._settingsItems['volume-eq'];
+        this._volumeEqSwitch.connect('notify::active', () => {
+            this._updateGsettings('volume-eq', this._volumeEqSwitch.active);
+        });
+        eqGroup.add(this._volumeEqSwitch);
+
+        const presetLabels = {
+            [EqPreset.DEFAULT]: _('Default'),
+            [EqPreset.HEAVY_BASS]: _('Heavy bass'),
+            [EqPreset.LIGHT_BASS]: _('Light bass'),
+            [EqPreset.BALANCED]: _('Balanced'),
+            [EqPreset.VOCAL_BOOST]: _('Vocal boost'),
+            [EqPreset.CLARITY]: _('Clarity'),
+            [EqPreset.LAST_SAVED]: _('Last saved'),
+            [EqPreset.CUSTOM]: _('Custom'),
+        };
+        const presetValues = [
+            EqPreset.DEFAULT,
+            EqPreset.HEAVY_BASS,
+            EqPreset.LIGHT_BASS,
+            EqPreset.BALANCED,
+            EqPreset.VOCAL_BOOST,
+            EqPreset.CLARITY,
+            EqPreset.LAST_SAVED,
+            EqPreset.CUSTOM,
+        ];
+        const initialPreset = this._settingsItems['eq-preset'] ??
+            this._eqPresetForCurrentEq();
+
+        this._eqPresetDropdown = new DropDownRowWidget({
+            title: _('Equalizer Preset'),
+            options: presetValues.map(preset => presetLabels[preset]),
+            values: presetValues,
+            initialValue: initialPreset,
+        });
+
+        this._eqPresetDropdown.connect('notify::selected-item', () => {
+            const preset = this._eqPresetDropdown.selected_item;
+            this._updateGsettings('eq-preset', preset);
+
+            if (preset === EqPreset.CUSTOM)
+                return;
+
+            const bands = preset === EqPreset.LAST_SAVED ?
+                this._settingsItems['eq-last-saved'] : EqPresetBands[preset];
+            this._eq.setValues(bands);
+            this._updateGsettings('eq-custom', bands);
+        });
+
+        eqGroup.add(this._eqPresetDropdown);
+
+        this._equalizerCustomRow = new Adw.ActionRow({
+            title: _('Custom Equalizer'),
+        });
+
+        const eqFreqs = [
+            _('Low Bass'),
+            _('Bass'),
+            _('Mid'),
+            _('Treble'),
+            _('Upper Treble'),
+        ];
+
+        this._eq = new EqualizerWidget(eqFreqs, this._settingsItems['eq-custom'], 6);
+        this._eq.connect('eq-changed', (_widget, values) => {
+            this._eqPresetDropdown.selected_item = EqPreset.CUSTOM;
+            this._updateGsettings('eq-preset', EqPreset.CUSTOM);
+            this._updateGsettings('eq-custom', values);
+        });
+
+        this._equalizerCustomRow.set_child(this._eq);
+        eqGroup.add(this._equalizerCustomRow);
+
+        const settingSignalId = settings.connect('changed::google-buds-list', () => {
+            const updatedList = settings.get_strv('google-buds-list').map(JSON.parse);
+            this._settingsItems = updatedList.find(info => info.path === devicePath);
+            if (!this._settingsItems)
+                return;
+
+            this.title = this._settingsItems.alias;
+            this._volumeEqSwitch.active = this._settingsItems['volume-eq'];
+            this._eqPresetDropdown.selected_item = this._settingsItems['eq-preset'] ??
+                this._eqPresetForCurrentEq();
+            this._eq.setValues(this._settingsItems['eq-custom']);
+        });
+
+        this.connect('close-request', () => {
+            this._eq?.destroy();
+            this._eq = null;
+
+            if (settingSignalId && settings)
+                settings.disconnect(settingSignalId);
+
+            settings = null;
+
+            return false;
+        });
+    }
+
+    _updateGsettings(key, value) {
+        const pairedDevice = this._settings.get_strv('google-buds-list');
+        const existingPathIndex =
+                pairedDevice.findIndex(item => JSON.parse(item).path === this._devicePath);
+        if (existingPathIndex !== -1) {
+            const existingItem = JSON.parse(pairedDevice[existingPathIndex]);
+            existingItem[key] = value;
+            pairedDevice[existingPathIndex] = JSON.stringify(existingItem);
+            this._settings.set_strv('google-buds-list', pairedDevice);
+        }
+    }
+
+    _eqPresetForCurrentEq() {
+        const staticPreset = eqPresetForBands(this._settingsItems['eq-custom']);
+        if (staticPreset !== EqPreset.CUSTOM)
+            return staticPreset;
+
+        if (JSON.stringify(this._settingsItems['eq-custom']) ===
+                JSON.stringify(this._settingsItems['eq-last-saved'])) {
+            return EqPreset.LAST_SAVED;
+        }
+
+        return EqPreset.CUSTOM;
+    }
+});


### PR DESCRIPTION
## Summary

Add initial Google Pixel Buds support using the Maestro RFCOMM profile.

This includes:
- detecting compatible Pixel Buds devices via the Maestro UUID and Bluetooth class
- reading battery/runtime information
- reading and setting ANC mode
- reading ANC gesture loop configuration
- reading and setting Volume EQ
- reading and setting 5-band custom EQ
- supporting Pixel Buds EQ presets, including the dynamic Last saved preset
- adding the Pixel Buds settings window
- wiring Google Buds storage, resources, metadata, and desktop keywords

## Testing

Tested locally with connected Pixel Buds Pro.

- Device is detected and shown in the BudsLink UI
- Battery/runtime info is read successfully
- ANC state reads successfully
- Volume EQ reads successfully
- Current EQ reads successfully
- Static EQ presets match values observed from the official app
- Last saved EQ is read and reflected in the UI
- EQ writes are serialized and read back after write

Also ran:

```bash
gjs -m src/lib/devices/googleBuds/googleBudsProtocol.js
gjs -m src/lib/devices/googleBuds/googleBudsSocket.js
gjs -m src/lib/devices/googleBuds/googleBudsDevice.js
gjs -m src/preferences/devices/googleBuds/configureWindow.js
git diff --check
```

## Credits

Protocol exploration and prior Linux Pixel Buds work from
[pbpctrl](https://github.com/qzed/pbpctrl) helped guide this implementation.

## Notes

The implementation currently targets Pixel Buds devices exposing the Maestro profile. It was validated with Pixel Buds Pro, so additional Pixel Buds models may need follow-up tuning if their runtime/settings payloads differ.
