### PR TITLE
RedmiBuds5Pro: Enable device configuration and guard missing noiseControl

### DIFF
--- a/src/lib/devices/redmiBuds/deviceConfigs/RedmiBuds5Pro.js
+++ b/src/lib/devices/redmiBuds/deviceConfigs/RedmiBuds5Pro.js
@@ -9,7 +9,6 @@ export default {
 
     batteryMutiple: true,
     batteryCase: true,
-    /*
     eqPreset: {
         standard: 0x00,
         treble: 0x06,
@@ -100,7 +99,6 @@ export default {
         },
         noiseControlModes: ['off', 'transparency', 'noise-cancellation'],
     },
-*/
     albumArtIcon: 'earbuds',
     budsIcon: 'earbuds',
     case: 'case-normal',

--- a/src/lib/devices/redmiBuds/redmiBudsSocket.js
+++ b/src/lib/devices/redmiBuds/redmiBudsSocket.js
@@ -652,8 +652,8 @@ export const RedmiBudsSocket = GObject.registerClass({
                 this._modelData.ancLevel;
 
         const hasAmbientStrength = this._modelData.transparencyStrength;
-        const ncByte = this._modelData.noiseControl.noiseCancellation;
-        const ambByte = this._modelData.noiseControl.transparency;
+        const ncByte = this._modelData.noiseControl?.noiseCancellation;
+        const ambByte = this._modelData.noiseControl?.transparency;
 
         if (mode === ncByte && hasNCStrength)
             this._callbacks?.updateAncStrength?.(strength);


### PR DESCRIPTION
Enables the Redmi Buds 5 Pro config and fixes the crash that made an
incomplete config look like a device that simply does not work.

Hardware: Redmi Buds 5 Pro, VID `0x2717`, PID `0x506D`, firmware 4.3.8.8.
Arch Linux, BlueZ 5.x, built from `c655162`.

### 1. `RedmiBuds5Pro`: enable device configuration

The device already matched the existing config, but with the whole block
commented out only battery levels came through. With it enabled the earbuds
answer every query and the app parses `NoiseControl`, `EqPreset`, `CustomEq`,
`Gestures`, `LongPressMode`, `LowLatency`, `DualConnection`, `AutoAnswer` and
`AdaptiveSound`. No errors in the log.

Setting noise control round trips, so the mode bytes are correct:

```
Set NoiseControl mode: 1  strength: 1
-> Sent     fe dc ba c4 f2 00 06 1e 04 00 0b 01 01 ef
<- Received fe dc ba c7 f4 00 06 26 04 00 0b 01 01 ef
Parse NoiseControl
UpdateNoiseControl mode: 0x01
```

I have exercised noise control and the battery readings directly. The other
features are enabled and negotiate correctly, but I have not verified each one
end to end — happy to test anything specific and report back.

### 2. `RedmiBudsSocket`: guard against a missing `noiseControl`

Worth applying regardless of the config change. Several Redmi/Xiaomi configs
ship with their block commented out while `batteryMutiple` and `batteryCase`
stay active, so a matching device connects and reports battery but has no
`noiseControl` entry.

The earbuds still send a noise control TLV in their run info, and
`_parseNoiseControl` dereferences the missing entry. The `TypeError` is thrown
inside the receive loop, which destroys the socket a few hundred ms after
connecting, so every later query times out:

```
Parse NoiseControl
UpdateNoiseControl mode: 0x00
ERR: SocketHandler Disconnected _parseNoiseControl@...redmiBudsSocket.js:655:24
Destroying socket
Response Timeout seq: 4 opcode: 0x09
Response Timeout seq: 5 opcode: 0xf3
```

From the outside this looks like "battery works, nothing else does", which is
what sent me digging. Optional chaining keeps the socket alive and the
comparisons below just fall through.

### Two unrelated observations

- These earbuds send the noise control TLV as `02 09 00` — mode only, no
  strength byte. `_decodeDeviceRunInfo` slices two bytes, so `strength` picks up
  the length byte of the next TLV. Cosmetic, but ANC strength reads wrong.
- Every `SET_CONFIG` gets an empty `0xf2` reply that logs `Unhandled opcode 0xf2`
  followed by a response timeout, while the setting itself applies fine. Looks
  generic to the Redmi path rather than specific to this model.

One thing that cost me a while and may be worth a note in the docs: the vendor
channel (`0000fd2d`) only accepts one host. While the earbuds were also
connected to my phone, `ConnectProfile` failed with `br-connection-refused`
before authentication. Disconnecting the phone fixed it.

Refs #62
