### PR TITLE
feat(devices): add support for CMF Buds Neo (B193)

### DIFF
--- a/src/io.github.maniacx.BudsLink.src.gresource.xml
+++ b/src/io.github.maniacx.BudsLink.src.gresource.xml
@@ -122,6 +122,7 @@
         <file>lib/devices/nothingBuds/nothingBudsSocket.js</file>
         <file>lib/devices/nothingBuds/deviceConfigs/BudsPro.js</file>
         <file>lib/devices/nothingBuds/deviceConfigs/CMFBuds.js</file>
+        <file>lib/devices/nothingBuds/deviceConfigs/CMFBudsNeo.js</file>
         <file>lib/devices/nothingBuds/deviceConfigs/CMFBuds2.js</file>
         <file>lib/devices/nothingBuds/deviceConfigs/CMFBuds2A.js</file>
         <file>lib/devices/nothingBuds/deviceConfigs/CMFBuds2Plus.js</file>

--- a/src/lib/devices/nothingBuds/deviceConfigs/CMFBudsNeo.js
+++ b/src/lib/devices/nothingBuds/deviceConfigs/CMFBudsNeo.js
@@ -1,0 +1,111 @@
+'use strict';
+
+export default {
+    modelId: 'B193',
+    name: 'CMF Buds Neo',
+    pattern: /^.*CMF Buds Neo$/,
+
+    batteryLR: true,
+    batteryCase: true,
+
+    eqPreset: {
+        dirac: 0x00,
+        pop: 0x03,
+        rock: 0x01,
+        electronic: 0x02,
+        enhance_vocals: 0x04,
+        classical: 0x05,
+        custom: 0x06,
+    },
+    eqListeningModeType: true,
+
+    bassEnhanceLevel: 5,
+
+    noiseControl: {
+        off: {byte: 0x05},
+        noiseCancellation: {byte: 0x04},
+        transparency: {byte: 0x07},
+    },
+
+    inEarDetection: false,
+    lowLatencyMode: true,
+    ring: true,
+    dualConnection: true,
+    dualConnectionReboot: false,
+    spatialAudioSwitch: true,
+
+    gestureOptions: {
+        default: '080201020902010308020107160201090103010209030103080301071603010901',
+        slots: [
+            {group: 'left',  device: 0x02, buttonId: 0x01, type: 'double'},
+            {group: 'left',  device: 0x02, buttonId: 0x01, type: 'triple'},
+            {group: 'left',  device: 0x02, buttonId: 0x01, type: 'action-hold'},
+            {group: 'left',  device: 0x02, buttonId: 0x01, type: 'double-action-hold'},
+            {group: 'right', device: 0x03, buttonId: 0x01, type: 'double'},
+            {group: 'right', device: 0x03, buttonId: 0x01, type: 'triple'},
+            {group: 'right', device: 0x03, buttonId: 0x01, type: 'action-hold'},
+            {group: 'right', device: 0x03, buttonId: 0x01, type: 'double-action-hold'},
+        ],
+        mapping: {
+            gestureTypes: {
+                'double': 0x02,
+                'triple': 0x03,
+                'action-hold': 0x07,
+                'double-action-hold': 0x09,
+            },
+            actions: {
+                'no-action': [0x01],
+                'play-pause': [0x02],
+                'skip-back': [0x08],
+                'skip-forward': [0x09],
+                'voice-assistant': [0x0B],
+                'volume-up': [0x12],
+                'volume-down': [0x13],
+                'noise-control': [0x0A, 0x14, 0x15, 0x16],
+            },
+        },
+        gestures: {
+            'double': {
+                type: 'tap',
+                actions: [
+                    'play-pause',
+                    'skip-back',
+                    'skip-forward',
+                    'voice-assistant',
+                    'no-action',
+                ],
+            },
+            'triple': {
+                type: 'tap',
+                actions: [
+                    'skip-back',
+                    'skip-forward',
+                    'voice-assistant',
+                    'no-action',
+                ],
+            },
+            'action-hold': {
+                type: 'tap',
+                actions: [
+                    'noise-control',
+                    'voice-assistant',
+                    'no-action',
+                ],
+            },
+            'double-action-hold': {
+                type: 'tap',
+                actions: [
+                    'volume-up',
+                    'volume-down',
+                    'voice-assistant',
+                    'no-action',
+                ],
+            },
+        },
+        noiseControlModes: ['off', 'transparency', 'noise-cancellation'],
+    },
+
+    albumArtIcon: 'earbuds-stem',
+    budsIcon: 'earbuds-stem',
+    case: 'case-square',
+};

--- a/src/lib/devices/nothingBuds/nothingBudsConfig.js
+++ b/src/lib/devices/nothingBuds/nothingBudsConfig.js
@@ -7,6 +7,7 @@ import CMFBuds2A from './deviceConfigs/CMFBuds2A.js';
 import CMFBuds2 from './deviceConfigs/CMFBuds2.js';
 import BudsPro from './deviceConfigs/BudsPro.js';
 import CMFBuds from './deviceConfigs/CMFBuds.js';
+import CMFBudsNeo from './deviceConfigs/CMFBudsNeo.js';
 import CMFHeadphonePro from './deviceConfigs/CMFHeadphonePro.js';
 import NeckbandPro from './deviceConfigs/NeckbandPro.js';
 import NothingHeadphone1 from './deviceConfigs/NothingHeadphone1.js';
@@ -29,6 +30,7 @@ export const NothingBudsModelList = [
     CMFBuds2,
     BudsPro,
     CMFBuds,
+    CMFBudsNeo,
     CMFHeadphonePro,
     NeckbandPro,
     NothingHeadphone1,


### PR DESCRIPTION
### Summary
Adds device configuration and protocol mapping for the **CMF Buds Neo** (`Model: B193`).

### Verified Features & Telemetry
- [x] **Battery Telemetry:** Left/Right individual percentages and dynamic case battery level (charging/active state reporting)
- [x] **Noise Control:** Three-state cycle (`Noise Cancellation`, `Transparency`, `Off`)
- [x] **Equalizer & Audio:** All standard presets supported (`Immersion Boost/Dirac`, `Pop`, `Rock`, `Electronic`, `Enhance Vocals`, `Classical`, `Custom`)
- [x] **Bass Enhancement:** Full slider control mapping (Levels 0–5)
- [x] **Spatial Audio:** Toggle functional with bidirectional state synchronization
- [x] **Game Mode (Low Latency):** Fully functional and syncs with Nothing X
- [x] **Device Actions:** Find My Earbuds (`Ring L/R`) and Dual Connection
- [x] **Touch Controls:** Complete gesture slot customization (Double tap, Triple tap, Tap & hold, Double tap & hold) including Voice Assistant triggers

### Testing Environment
- **Hardware:** CMF Buds Neo (Model B193)
- **OS:** Fedora Linux
- **Build Target:** GNOME Flatpak (`io.github.maniacx.BudsLink`)

### Screenshots

| Main Controls & Telemetry | Sound & Spatial Audio | Gesture Mapping |
| :---: | :---: | :---: |
| <img width="410" height="830" alt="Screenshot From 2026-09-01 00-00-35" src="https://github.com/user-attachments/assets/f03be3cb-b50a-446d-bc5c-a9e32fd766d4" /> | <img width="700" height="700" alt="Screenshot From 2026-09-01 00-00-51" src="https://github.com/user-attachments/assets/36d944a5-1be1-4c0f-8d16-63e87c14d2ef" /> | <img width="700" height="700" alt="Screenshot From 2026-09-01 00-02-00" src="https://github.com/user-attachments/assets/2a9c2b40-c3e3-4d2d-8f0d-cfd2d91e9fd8" /> |