### PR TITLE
Add selectable interface language support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 log
 config
+build
 build-dir
 .flatpak-builder
 localdata
 repo
+subprojects/.wraplock
+data/gschemas.compiled
+gschemas.compiled

--- a/data/io.github.maniacx.BudsLink.gschema.xml
+++ b/data/io.github.maniacx.BudsLink.gschema.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist gettext-domain="budslink">
     <schema id="io.github.maniacx.BudsLink" path="/io/github/maniacx/BudsLink/">
+        <key name="language" type="s">
+            <default>'system'</default>
+        </key>
         <key name="dark-mode" type="s">
             <default>'system'</default>
         </key>

--- a/data/meson.build
+++ b/data/meson.build
@@ -50,11 +50,17 @@ i18n.merge_file(
   install_dir: get_option('datadir') / 'metainfo'
 )
 
+configure_file(
+  input: APP_ID + '.gschema.xml',
+  output: APP_ID + '.gschema.xml',
+  copy: true,
+)
+
 install_data(APP_ID + '.gschema.xml',
   install_dir: get_option('datadir') / 'glib-2.0/schemas',
 )
 
-gnome.compile_schemas()
+gnome.compile_schemas(build_by_default: true)
 
 compile_schemas = find_program('glib-compile-schemas', required: false)
 if compile_schemas.found()

--- a/po/io.github.maniacx.BudsLink.pot
+++ b/po/io.github.maniacx.BudsLink.pot
@@ -82,6 +82,10 @@ msgstr ""
 msgid "Accent Color"
 msgstr ""
 
+#: src/appLibs/widgets/settingsButton.js:80
+msgid "Language"
+msgstr ""
+
 #: src/appLibs/widgets/settingsButton.js:77
 msgid "Packet Logging"
 msgstr ""
@@ -104,6 +108,10 @@ msgstr ""
 
 #: src/appLibs/widgets/settingsButton.js:185
 msgid "Dark"
+msgstr ""
+
+#: src/appLibs/widgets/settingsButton.js:307
+msgid "Restart required to apply language change"
 msgstr ""
 
 #: src/appLibs/widgets/settingsButton.js:301

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,16 +1,16 @@
 # Russian translations for BudsLink package.
 # Copyright (C) 2026 maniacx@github.com
 # This file is distributed under the same license as the BudsLink package.
-# Automatically generated, 2026.
+# Andrey Sychin <moloko@skofey.com>, 2026.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: BudsLink\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-20 17:29-0600\n"
-"PO-Revision-Date: 2026-01-28 21:26-0700\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"POT-Creation-Date: 2026-08-25 13:30-0600\n"
+"PO-Revision-Date: 2026-09-07 00:00+0700\n"
+"Last-Translator: Andrey Sychin <moloko@skofey.com>\n"
+"Language-Team: Russian\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,99 +20,107 @@ msgstr ""
 
 #: src/app.js:190 src/appLibs/widgets/deviceRow.js:56
 msgid "BudsLink"
-msgstr ""
+msgstr "BudsLink"
 
 #: src/app.js:200
 msgid "Devices"
-msgstr ""
+msgstr "Устройства"
 
 #: src/app.js:202
 msgid "No compatible device found"
-msgstr ""
+msgstr "Совместимые устройства не найдены"
 
 #: src/appLibs/widgets/settingsButton.js:24
 msgid "Application Settings"
-msgstr ""
+msgstr "Настройки приложения"
 
 #: src/appLibs/widgets/settingsButton.js:33
 #: src/appLibs/widgets/settingsButton.js:183
 msgid "System Default"
-msgstr ""
+msgstr "Системный по умолчанию"
 
 #: src/appLibs/widgets/settingsButton.js:34
 msgid "Blue"
-msgstr ""
+msgstr "Синий"
 
 #: src/appLibs/widgets/settingsButton.js:35
 msgid "Teal"
-msgstr ""
+msgstr "Бирюзовый"
 
 #: src/appLibs/widgets/settingsButton.js:36
 msgid "Green"
-msgstr ""
+msgstr "Зелёный"
 
 #: src/appLibs/widgets/settingsButton.js:37
 msgid "Yellow"
-msgstr ""
+msgstr "Жёлтый"
 
 #: src/appLibs/widgets/settingsButton.js:38
 msgid "Orange"
-msgstr ""
+msgstr "Оранжевый"
 
 #: src/appLibs/widgets/settingsButton.js:39
 msgid "Red"
-msgstr ""
+msgstr "Красный"
 
 #: src/appLibs/widgets/settingsButton.js:40
 msgid "Pink"
-msgstr ""
+msgstr "Розовый"
 
 #: src/appLibs/widgets/settingsButton.js:41
 msgid "Purple"
-msgstr ""
+msgstr "Фиолетовый"
 
 #: src/appLibs/widgets/settingsButton.js:42
 msgid "Slate"
-msgstr ""
+msgstr "Грифельный"
 
 #: src/appLibs/widgets/settingsButton.js:63
 msgid "Dark Mode"
-msgstr ""
+msgstr "Тёмная тема"
 
 #: src/appLibs/widgets/settingsButton.js:70
 msgid "Accent Color"
-msgstr ""
+msgstr "Цветовой акцент"
+
+#: src/appLibs/widgets/settingsButton.js:80
+msgid "Language"
+msgstr "Язык"
 
 #: src/appLibs/widgets/settingsButton.js:77
 msgid "Packet Logging"
-msgstr ""
+msgstr "Журналирование пакетов"
 
 #: src/appLibs/widgets/settingsButton.js:84
 msgid "BudsLink Companion"
-msgstr ""
+msgstr "BudsLink Companion"
 
 #: src/appLibs/widgets/settingsButton.js:91
 msgid "About BudsLink"
-msgstr ""
+msgstr "О программе BudsLink"
 
 #: src/appLibs/widgets/settingsButton.js:102
 msgid "Translation"
-msgstr ""
+msgstr "Перевод"
 
 #: src/appLibs/widgets/settingsButton.js:184
 msgid "Light"
-msgstr ""
+msgstr "Светлая"
 
 #: src/appLibs/widgets/settingsButton.js:185
 msgid "Dark"
-msgstr ""
+msgstr "Тёмная"
+
+#: src/appLibs/widgets/settingsButton.js:307
+msgid "Restart required to apply language change"
+msgstr "Для применения изменения языка требуется перезапуск"
 
 #: src/appLibs/widgets/settingsButton.js:301
 #: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:691
 #: src/lib/devices/sony/sonyDevice.js:213
 #: src/lib/devices/airpods/airpodsDevice.js:241
 msgid "On"
-msgstr ""
+msgstr "Вкл"
 
 #: src/appLibs/widgets/settingsButton.js:302
 #: src/preferences/devices/senhBuds/configureWindow.js:227
@@ -146,27 +154,27 @@ msgstr ""
 #: src/lib/devices/airpods/airpodsDevice.js:201
 #: src/lib/devices/airpods/airpodsDevice.js:243
 msgid "Off"
-msgstr ""
+msgstr "Выкл"
 
 #: src/appLibs/widgets/settingsButton.js:364
 msgid "GNOME Extension"
-msgstr ""
+msgstr "Расширение GNOME"
 
 #: src/appLibs/widgets/settingsButton.js:370
 msgid "Plasma Widget"
-msgstr ""
+msgstr "Виджет Plasma"
 
 #: src/appLibs/widgets/settingsButton.js:376
 msgid "Cinnamon Spice"
-msgstr ""
+msgstr "Апплет Cinnamon"
 
 #: src/appLibs/widgets/deviceRow.js:98
 msgid "Configure"
-msgstr ""
+msgstr "Настроить"
 
 #: src/appLibs/widgets/deviceRow.js:110
 msgid "Battery Level"
-msgstr ""
+msgstr "Уровень заряда"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:92
 #: src/preferences/devices/redmiBuds/configureWindow.js:93
@@ -179,7 +187,7 @@ msgstr ""
 #: src/preferences/devices/sony/configureWindow.js:88
 #: src/preferences/devices/airpods/configureWindow.js:83
 msgid "Icon"
-msgstr ""
+msgstr "Значок"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:93
 #: src/preferences/devices/redmiBuds/configureWindow.js:94
@@ -192,7 +200,7 @@ msgstr ""
 #: src/preferences/devices/sony/configureWindow.js:89
 #: src/preferences/devices/airpods/configureWindow.js:84
 msgid "Select Icon"
-msgstr ""
+msgstr "Выбрать значок"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:94
 #: src/preferences/devices/redmiBuds/configureWindow.js:95
@@ -205,12 +213,12 @@ msgstr ""
 #: src/preferences/devices/sony/configureWindow.js:90
 #: src/preferences/devices/airpods/configureWindow.js:85
 msgid "Select the icon used for the indicator and quick menu"
-msgstr ""
+msgstr "Выберите значок для индикатора и быстрого меню"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:220
 #: src/preferences/devices/boseBuds/configureWindow.js:272
 msgid "Sound Settings"
-msgstr ""
+msgstr "Настройки звука"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:228
 #: src/preferences/devices/redmiBuds/configureWindow.js:209
@@ -219,61 +227,61 @@ msgstr ""
 #: src/preferences/devices/googleBuds/configureWindow.js:69
 #: src/preferences/devices/sony/configureWindow.js:209
 msgid "Equalizer"
-msgstr ""
+msgstr "Эквалайзер"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:229
 msgid "Podcast"
-msgstr ""
+msgstr "Подкаст"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:230
 msgid "Sound personalization"
-msgstr ""
+msgstr "Персонализация звука"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:231
 #: src/preferences/widgets/peqRowWidget.js:883
 #: src/preferences/widgets/peqRowWidget.js:1308
 msgid "Parametric Equalizer"
-msgstr ""
+msgstr "Параметрический эквалайзер"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:242
 msgid "Audio Mode"
-msgstr ""
+msgstr "Аудиорежим"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:262
 #: src/preferences/devices/boseBuds/configureWindow.js:281
 msgid "Flat"
-msgstr ""
+msgstr "Плоский"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:263
 #: src/preferences/devices/nothingBuds/configureWindow.js:222
 msgid "Rock"
-msgstr ""
+msgstr "Рок"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:264
 #: src/preferences/devices/nothingBuds/configureWindow.js:224
 msgid "Pop"
-msgstr ""
+msgstr "Поп"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:265
 msgid "Dance"
-msgstr ""
+msgstr "Танцевальная"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:266
 msgid "Hip Hop"
-msgstr ""
+msgstr "Хип-хоп"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:267
 #: src/preferences/devices/nothingBuds/configureWindow.js:226
 msgid "Classical"
-msgstr ""
+msgstr "Классика"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:268
 msgid "Movie"
-msgstr ""
+msgstr "Фильм"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:269
 msgid "Jazz"
-msgstr ""
+msgstr "Джаз"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:282
 #: src/preferences/devices/redmiBuds/configureWindow.js:220
@@ -281,7 +289,7 @@ msgstr ""
 #: src/preferences/devices/googleBuds/configureWindow.js:89
 #: src/preferences/devices/boseBuds/configureWindow.js:298
 msgid "Custom"
-msgstr ""
+msgstr "Пользовательский"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:288
 #: src/preferences/devices/redmiBuds/configureWindow.js:241
@@ -290,7 +298,7 @@ msgstr ""
 #: src/preferences/devices/boseBuds/configureWindow.js:304
 #: src/preferences/devices/sony/configureWindow.js:248
 msgid "Custom Equalizer"
-msgstr ""
+msgstr "Пользовательский эквалайзер"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:293
 #: src/preferences/devices/redmiBuds/configureWindow.js:246
@@ -301,104 +309,104 @@ msgstr ""
 #: src/preferences/devices/boseBuds/configureWindow.js:310
 #: src/preferences/devices/sony/configureWindow.js:242
 msgid "Equalizer Preset"
-msgstr ""
+msgstr "Пресет эквалайзера"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:303
 msgid "50"
-msgstr ""
+msgstr "50"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:304
 #: src/preferences/devices/sony/configureWindow.js:260
 msgid "63"
-msgstr ""
+msgstr "63"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:305
 #: src/preferences/devices/redmiBuds/configureWindow.js:262
 #: src/preferences/devices/sony/configureWindow.js:260
 msgid "125"
-msgstr ""
+msgstr "125"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:306
 #: src/preferences/devices/redmiBuds/configureWindow.js:262
 #: src/preferences/devices/sony/configureWindow.js:260
 msgid "250"
-msgstr ""
+msgstr "250"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:307
 #: src/preferences/devices/sony/configureWindow.js:259
 msgid "400"
-msgstr ""
+msgstr "400"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:308
 #: src/preferences/devices/redmiBuds/configureWindow.js:262
 #: src/preferences/devices/sony/configureWindow.js:260
 msgid "500"
-msgstr ""
+msgstr "500"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:309
 msgid "800"
-msgstr ""
+msgstr "800"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:310
 #: src/preferences/devices/redmiBuds/configureWindow.js:262
 #: src/preferences/devices/sony/configureWindow.js:259
 #: src/preferences/devices/sony/configureWindow.js:261
 msgid "1k"
-msgstr ""
+msgstr "1k"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:311
 #: src/preferences/devices/redmiBuds/configureWindow.js:262
 #: src/preferences/devices/sony/configureWindow.js:261
 msgid "2k"
-msgstr ""
+msgstr "2k"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:312
 #: src/preferences/devices/sony/configureWindow.js:259
 msgid "2.5k"
-msgstr ""
+msgstr "2.5k"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:313
 msgid "3k"
-msgstr ""
+msgstr "3k"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:314
 #: src/preferences/devices/redmiBuds/configureWindow.js:262
 #: src/preferences/devices/sony/configureWindow.js:261
 msgid "4k"
-msgstr ""
+msgstr "4k"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:315
 #: src/preferences/devices/sony/configureWindow.js:259
 msgid "6.3k"
-msgstr ""
+msgstr "6.3k"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:316
 msgid "7k"
-msgstr ""
+msgstr "7k"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:317
 #: src/preferences/devices/redmiBuds/configureWindow.js:263
 #: src/preferences/devices/sony/configureWindow.js:261
 msgid "8k"
-msgstr ""
+msgstr "8k"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:318
 #: src/preferences/devices/redmiBuds/configureWindow.js:263
 msgid "12k"
-msgstr ""
+msgstr "12k"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:319
 #: src/preferences/devices/redmiBuds/configureWindow.js:263
 #: src/preferences/devices/sony/configureWindow.js:259
 #: src/preferences/devices/sony/configureWindow.js:261
 msgid "16k"
-msgstr ""
+msgstr "16k"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:336
 #: src/preferences/devices/redmiBuds/configureWindow.js:272
 #: src/preferences/devices/sony/configureWindow.js:270
 msgid "Frequency (Hz)"
-msgstr ""
+msgstr "Частота (Гц)"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:337
 #: src/preferences/devices/redmiBuds/configureWindow.js:273
@@ -407,12 +415,12 @@ msgstr ""
 #: src/preferences/devices/boseBuds/configureWindow.js:338
 #: src/preferences/devices/sony/configureWindow.js:271
 msgid "Gain (dB)"
-msgstr ""
+msgstr "Усиление (дБ)"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:364
 #: src/preferences/devices/nothingBuds/configureWindow.js:288
 msgid "Enable Bass Boost"
-msgstr ""
+msgstr "Включить усиление басов"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:439
 #: src/preferences/devices/boseBuds/configureWindow.js:490
@@ -422,7 +430,7 @@ msgstr ""
 #: src/lib/devices/boseBuds/boseBudsDevice.js:676
 #: src/lib/devices/sony/sonyDevice.js:197
 msgid "Low"
-msgstr ""
+msgstr "Низкий"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:440
 #: src/preferences/devices/boseBuds/configureWindow.js:492
@@ -432,87 +440,87 @@ msgstr ""
 #: src/lib/devices/boseBuds/boseBudsDevice.js:677
 #: src/lib/devices/sony/sonyDevice.js:197
 msgid "High"
-msgstr ""
+msgstr "Высокий"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:451
 msgid "Crossfeed"
-msgstr ""
+msgstr "Кроссфид"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:557
 #: src/preferences/devices/boseBuds/configureWindow.js:371
 msgid "In Ear Settings"
-msgstr ""
+msgstr "Настройки наушников-вкладышей"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:557
 #: src/preferences/devices/boseBuds/configureWindow.js:372
 msgid "On Head Settings"
-msgstr ""
+msgstr "Настройки полноразмерных наушников"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:562
 #: src/preferences/devices/boseBuds/configureWindow.js:378
 msgid "Enable In-Ear Detection"
-msgstr ""
+msgstr "Включить автообнаружение в ухе"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:563
 #: src/preferences/devices/boseBuds/configureWindow.js:379
 msgid "Enable On Head Detection"
-msgstr ""
+msgstr "Включить автообнаружение на голове"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:576
 #: src/preferences/devices/boseBuds/configureWindow.js:393
 msgid "Pause Media When Not Worn"
-msgstr ""
+msgstr "Пауза воспроизведения при снятии"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:577
 #: src/preferences/devices/boseBuds/configureWindow.js:394
 msgid "Playback controlled by the OEM app"
-msgstr ""
+msgstr "Воспроизведением управляет фирменное приложение"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:589
 #: src/preferences/devices/boseBuds/configureWindow.js:406
 msgid "Automatically Answer Calls When Worn"
-msgstr ""
+msgstr "Автоматически отвечать на вызовы при надевании"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:601
 msgid "Pause Media When Transparency Mode Is Enabled"
-msgstr ""
+msgstr "Пауза воспроизведения при включении режима прозрачности"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:613
 #: src/preferences/devices/boseBuds/configureWindow.js:562
 msgid "Never"
-msgstr ""
+msgstr "Никогда"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:614
 msgid "After 15 minutes"
-msgstr ""
+msgstr "Через 15 минут"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:615
 #: src/preferences/devices/sony/configureWindow.js:478
 msgid "After 30 minutes"
-msgstr ""
+msgstr "Через 30 минут"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:616
 #: src/preferences/devices/boseBuds/configureWindow.js:566
 #: src/preferences/devices/sony/configureWindow.js:479
 msgid "After 1 hour"
-msgstr ""
+msgstr "Через 1 час"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:624
 #: src/preferences/devices/sony/configureWindow.js:491
 msgid "Automatically Power Off When Not Worn"
-msgstr ""
+msgstr "Автоматически выключать при отсутствии ношения"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:639
 #: src/preferences/devices/galaxyBuds/configureWindow.js:115
 #: src/preferences/devices/boseBuds/configureWindow.js:430
 #: src/preferences/devices/airpods/configureWindow.js:106
 msgid "Playback Behavior"
-msgstr ""
+msgstr "Поведение воспроизведения"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:640
 #: src/preferences/devices/boseBuds/configureWindow.js:431
 msgid "Playback controlled by the BudsLink"
-msgstr ""
+msgstr "Воспроизведением управляет BudsLink"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:644
 #: src/preferences/devices/senhBuds/configureWindow.js:648
@@ -522,159 +530,161 @@ msgstr ""
 #: src/preferences/devices/airpods/configureWindow.js:110
 #: src/preferences/devices/airpods/configureWindow.js:113
 msgid "Default behavior"
-msgstr ""
+msgstr "Поведение по умолчанию"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:645
 #: src/preferences/devices/galaxyBuds/configureWindow.js:120
 #: src/preferences/devices/boseBuds/configureWindow.js:436
 #: src/preferences/devices/airpods/configureWindow.js:114
 msgid "Resume with both earbuds, Pause if any removed"
-msgstr ""
+msgstr "Возобновлять при надевании обоих, пауза при снятии любого"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:646
 #: src/preferences/devices/galaxyBuds/configureWindow.js:121
 #: src/preferences/devices/boseBuds/configureWindow.js:437
 #: src/preferences/devices/airpods/configureWindow.js:115
 msgid "Resume with any earbud, Pause if both removed"
-msgstr ""
+msgstr "Возобновлять при надевании любого, пауза при снятии обоих"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:649
 #: src/preferences/devices/boseBuds/configureWindow.js:440
 #: src/preferences/devices/airpods/configureWindow.js:111
 msgid "Resume when worn"
-msgstr ""
+msgstr "Возобновлять при надевании"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:653
 #: src/preferences/devices/boseBuds/configureWindow.js:444
 msgid "Choose playback behavior for in-ear detection"
-msgstr ""
+msgstr "Выберите поведение воспроизведения при автообнаружении в ухе"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:654
 #: src/preferences/devices/boseBuds/configureWindow.js:445
 msgid "Choose playback behavior for on-head detection"
-msgstr ""
+msgstr "Выберите поведение воспроизведения при автообнаружении на голове"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:658
 #: src/preferences/devices/galaxyBuds/configureWindow.js:126
 #: src/preferences/devices/boseBuds/configureWindow.js:449
 #: src/preferences/devices/airpods/configureWindow.js:120
 msgid "Automatically pause or resume playback based on wearing detection."
-msgstr ""
+msgstr "Автоматически ставить на паузу или возобновлять воспроизведение при надевании/снятии."
+"Автоматически ставить на паузу или возобновлять воспроизведение при "
+"надевании/снятии."
 
 #: src/preferences/devices/senhBuds/configureWindow.js:692
 #: src/preferences/devices/boseBuds/configureWindow.js:485
 msgid "Calls Settings"
-msgstr ""
+msgstr "Настройки вызовов"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:704
 #: src/preferences/devices/galaxyBuds/configureWindow.js:622
 #: src/preferences/devices/boseBuds/configureWindow.js:499
 msgid "Ambient Sound During Calls"
-msgstr ""
+msgstr "Окружающий звук во время вызовов"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:721
 msgid "Comfort Calls"
-msgstr ""
+msgstr "Комфортные вызовы"
 
 #: src/preferences/devices/senhBuds/configureWindow.js:736
 #: src/preferences/devices/sony/configureWindow.js:613
 msgid "Connection Management"
-msgstr ""
+msgstr "Управление подключениями"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:215
 #: src/preferences/devices/sony/configureWindow.js:130
 #: src/preferences/devices/sony/configureWindow.js:154
 #: src/lib/devices/sony/sonyDevice.js:197
 msgid "Standard"
-msgstr ""
+msgstr "Стандартный"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:216
 #: src/preferences/devices/nothingBuds/configureWindow.js:218
 #: src/lib/devices/redmiBuds/redmiBudsDevice.js:634
 msgid "Voice"
-msgstr ""
+msgstr "Голос"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:217
 #: src/preferences/devices/nothingBuds/configureWindow.js:220
 msgid "More Bass"
-msgstr ""
+msgstr "Больше басов"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:218
 #: src/preferences/devices/nothingBuds/configureWindow.js:219
 msgid "More Treble"
-msgstr ""
+msgstr "Больше высоких частот"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:219
 msgid "Volume Boost"
-msgstr ""
+msgstr "Усиление громкости"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:221
 msgid "Classic"
-msgstr ""
+msgstr "Классический"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:222
 msgid "Audiophile"
-msgstr ""
+msgstr "Аудиофильский"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:223
 msgid "Decrease bass"
-msgstr ""
+msgstr "Уменьшение басов"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:224
 msgid "Harman EFX"
-msgstr ""
+msgstr "Harman EFX"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:225
 msgid "Harman Master"
-msgstr ""
+msgstr "Harman Master"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:226
 msgid "Standard 2"
-msgstr ""
+msgstr "Стандартный 2"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:227
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:627
 msgid "Outdoor"
-msgstr ""
+msgstr "На улице"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:228
 msgid "Underwater"
-msgstr ""
+msgstr "Под водой"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:229
 #: src/preferences/devices/nothingBuds/configureWindow.js:217
 #: src/preferences/devices/googleBuds/configureWindow.js:85
 msgid "Balanced"
-msgstr ""
+msgstr "Сбалансированный"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:262
 msgid "62"
-msgstr ""
+msgstr "62"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:290
 #: src/preferences/devices/nothingBuds/configureWindow.js:355
 #: src/preferences/devices/galaxyBuds/configureWindow.js:616
 #: src/preferences/devices/boseBuds/configureWindow.js:518
 msgid "Additional Settings"
-msgstr ""
+msgstr "Дополнительные настройки"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:296
 #: src/preferences/widgets/deviceMgmtRowWidget.js:459
 msgid "Allow Connections to Multiple Devices"
-msgstr ""
+msgstr "Разрешить подключение к нескольким устройствам"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:310
 msgid "Automatically answer phone calls"
-msgstr ""
+msgstr "Автоматически отвечать на телефонные вызовы"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:324
 msgid "Adaptive Sound"
-msgstr ""
+msgstr "Адаптивный звук"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:338
 #: src/preferences/devices/nothingBuds/configureWindow.js:360
 msgid "Enable low latency mode"
-msgstr ""
+msgstr "Включить режим низкой задержки"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:370
 #: src/preferences/devices/nothingBuds/configureWindow.js:409
@@ -683,7 +693,7 @@ msgstr ""
 #: src/lib/devices/redmiBuds/redmiBudsDevice.js:635
 #: src/lib/devices/sony/sonyDevice.js:184
 msgid "Ambient"
-msgstr ""
+msgstr "Окружающий звук"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:371
 #: src/preferences/devices/nothingBuds/configureWindow.js:410
@@ -702,12 +712,12 @@ msgstr ""
 #: src/lib/devices/sony/sonyDevice.js:187
 #: src/lib/devices/airpods/airpodsDevice.js:204
 msgid "Noise Cancellation"
-msgstr ""
+msgstr "Шумоподавление"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:375
 #: src/preferences/devices/nothingBuds/configureWindow.js:419
 msgid "Noise Control Cycle: "
-msgstr ""
+msgstr "Цикл управления шумом: "
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:377
 #: src/preferences/devices/nothingBuds/configureWindow.js:421
@@ -716,54 +726,54 @@ msgstr ""
 #: src/preferences/devices/sony/configureWindow.js:376
 #: src/preferences/devices/airpods/configureWindow.js:258
 msgid "Apply"
-msgstr ""
+msgstr "Применить"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:399
 #: src/preferences/devices/nothingBuds/configureWindow.js:441
 #: src/preferences/devices/galaxyBuds/configureWindow.js:356
 #: src/preferences/devices/boseBuds/configureWindow.js:674
 msgid "Single Tap"
-msgstr ""
+msgstr "Одиночное касание"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:400
 #: src/preferences/devices/nothingBuds/configureWindow.js:442
 #: src/preferences/devices/galaxyBuds/configureWindow.js:369
 #: src/preferences/devices/boseBuds/configureWindow.js:675
 msgid "Double Tap"
-msgstr ""
+msgstr "Двойное касание"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:401
 #: src/preferences/devices/nothingBuds/configureWindow.js:443
 #: src/preferences/devices/galaxyBuds/configureWindow.js:382
 #: src/preferences/devices/boseBuds/configureWindow.js:676
 msgid "Triple Tap"
-msgstr ""
+msgstr "Тройное касание"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:402
 #: src/preferences/devices/nothingBuds/configureWindow.js:444
 msgid "Tap and Hold"
-msgstr ""
+msgstr "Касание и удержание"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:404
 #: src/preferences/devices/nothingBuds/configureWindow.js:447
 #: src/preferences/devices/nothingBuds/configureWindow.js:462
 #: src/preferences/devices/boseBuds/configureWindow.js:680
 msgid "Single Press"
-msgstr ""
+msgstr "Одиночное нажатие"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:405
 #: src/preferences/devices/nothingBuds/configureWindow.js:448
 #: src/preferences/devices/nothingBuds/configureWindow.js:463
 #: src/preferences/devices/boseBuds/configureWindow.js:681
 msgid "Double Press"
-msgstr ""
+msgstr "Двойное нажатие"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:406
 #: src/preferences/devices/nothingBuds/configureWindow.js:449
 #: src/preferences/devices/nothingBuds/configureWindow.js:464
 #: src/preferences/devices/boseBuds/configureWindow.js:682
 msgid "Triple Press"
-msgstr ""
+msgstr "Тройное нажатие"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:407
 #: src/preferences/devices/nothingBuds/configureWindow.js:450
@@ -771,65 +781,65 @@ msgstr ""
 #: src/preferences/devices/nothingBuds/configureWindow.js:465
 #: src/preferences/devices/boseBuds/configureWindow.js:683
 msgid "Press and Hold"
-msgstr ""
+msgstr "Нажатие и удержание"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:409
 #: src/preferences/devices/nothingBuds/configureWindow.js:453
 #: src/preferences/devices/boseBuds/configureWindow.js:686
 msgid "Single Pinch"
-msgstr ""
+msgstr "Одиночное сжатие"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:410
 #: src/preferences/devices/nothingBuds/configureWindow.js:454
 #: src/preferences/devices/boseBuds/configureWindow.js:687
 msgid "Double Pinch"
-msgstr ""
+msgstr "Двойное сжатие"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:411
 #: src/preferences/devices/nothingBuds/configureWindow.js:455
 #: src/preferences/devices/boseBuds/configureWindow.js:688
 msgid "Triple Pinch"
-msgstr ""
+msgstr "Тройное сжатие"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:412
 #: src/preferences/devices/nothingBuds/configureWindow.js:456
 #: src/preferences/devices/boseBuds/configureWindow.js:689
 msgid "Pinch and Hold"
-msgstr ""
+msgstr "Сжатие и удержание"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:414
 msgid "Swipe"
-msgstr ""
+msgstr "Свайп"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:418
 #: src/preferences/devices/nothingBuds/configureWindow.js:600
 #: src/preferences/devices/boseBuds/configureWindow.js:757
 msgid "Left Buds Gesture Control"
-msgstr ""
+msgstr "Жесты левого наушника"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:422
 #: src/preferences/devices/nothingBuds/configureWindow.js:603
 #: src/preferences/devices/boseBuds/configureWindow.js:760
 msgid "Right Buds Gesture Control"
-msgstr ""
+msgstr "Жесты правого наушника"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:489
 #: src/preferences/devices/nothingBuds/configureWindow.js:622
 #: src/preferences/devices/boseBuds/configureWindow.js:802
 msgid "Play / Pause"
-msgstr ""
+msgstr "Воспроизведение / Пауза"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:492
 #: src/preferences/devices/nothingBuds/configureWindow.js:625
 #: src/preferences/devices/boseBuds/configureWindow.js:817
 msgid "Previous Track"
-msgstr ""
+msgstr "Предыдущий трек"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:495
 #: src/preferences/devices/nothingBuds/configureWindow.js:628
 #: src/preferences/devices/boseBuds/configureWindow.js:820
 msgid "Next Track"
-msgstr ""
+msgstr "Следующий трек"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:498
 #: src/preferences/devices/nothingBuds/configureWindow.js:631
@@ -837,17 +847,17 @@ msgstr ""
 #: src/preferences/devices/boseBuds/configureWindow.js:787
 #: src/preferences/devices/boseBuds/configureWindow.js:793
 msgid "Voice Assistant"
-msgstr ""
+msgstr "Голосовой помощник"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:501
 #: src/preferences/devices/nothingBuds/configureWindow.js:634
 msgid "Volume Up"
-msgstr ""
+msgstr "Увеличить громкость"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:504
 #: src/preferences/devices/nothingBuds/configureWindow.js:637
 msgid "Volume Down"
-msgstr ""
+msgstr "Уменьшить громкость"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:507
 #: src/preferences/devices/nothingBuds/configureWindow.js:643
@@ -867,40 +877,40 @@ msgstr ""
 #: src/lib/devices/sony/sonyDevice.js:180
 #: src/lib/devices/airpods/airpodsDevice.js:174
 msgid "Noise Control"
-msgstr ""
+msgstr "Управление шумом"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:510
 #: src/preferences/devices/nothingBuds/configureWindow.js:649
 #: src/preferences/devices/boseBuds/configureWindow.js:772
 msgid "No Action"
-msgstr ""
+msgstr "Нет действия"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:513
 #: src/preferences/devices/nothingBuds/configureWindow.js:652
 msgid "Change Volume"
-msgstr ""
+msgstr "Изменение громкости"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:516
 #: src/preferences/devices/nothingBuds/configureWindow.js:679
 msgid "Toggle Low Latency"
-msgstr ""
+msgstr "Вкл/Выкл низкую задержку"
 
 #: src/preferences/devices/redmiBuds/configureWindow.js:519
 #: src/preferences/devices/nothingBuds/configureWindow.js:685
 msgid "Take Photo"
-msgstr ""
+msgstr "Сделать фото"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:221
 msgid "Dirac"
-msgstr ""
+msgstr "Dirac"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:223
 msgid "Electronic"
-msgstr ""
+msgstr "Электронная"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:225
 msgid "Enhance Vocals"
-msgstr ""
+msgstr "Усиление вокала"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:260
 #: src/preferences/devices/nothingBuds/configureWindow.js:673
@@ -908,7 +918,7 @@ msgstr ""
 #: src/preferences/devices/boseBuds/configureWindow.js:320
 #: src/preferences/devices/sony/configureWindow.js:259
 msgid "Bass"
-msgstr ""
+msgstr "Бас"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:260
 #: src/preferences/devices/googleBuds/configureWindow.js:132
@@ -916,14 +926,14 @@ msgstr ""
 #: src/lib/devices/redmiBuds/redmiBudsDevice.js:589
 #: src/lib/devices/nothingBuds/nothingBudsDevice.js:397
 msgid "Mid"
-msgstr ""
+msgstr "Средний"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:260
 #: src/preferences/devices/nothingBuds/configureWindow.js:676
 #: src/preferences/devices/googleBuds/configureWindow.js:133
 #: src/preferences/devices/boseBuds/configureWindow.js:322
 msgid "Treble"
-msgstr ""
+msgstr "Высокие"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:268
 #: src/preferences/devices/googleBuds/configureWindow.js:141
@@ -931,26 +941,26 @@ msgstr ""
 #: src/preferences/widgets/peqRowWidget.js:983
 #: src/preferences/widgets/peqRowWidget.js:1154
 msgid "Band"
-msgstr ""
+msgstr "Полоса"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:285
 #: src/preferences/devices/galaxyBuds/configureWindow.js:275
 #: src/preferences/devices/boseBuds/configureWindow.js:282
 #: src/preferences/devices/sony/configureWindow.js:219
 msgid "Bass Boost"
-msgstr ""
+msgstr "Усиление басов"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:300
 msgid "Bass Boost Level"
-msgstr ""
+msgstr "Уровень усиления басов"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:303
 msgid "-"
-msgstr ""
+msgstr "-"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:307
 msgid "+"
-msgstr ""
+msgstr "+"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:335
 #: src/preferences/devices/nothingBuds/configureWindow.js:661
@@ -959,220 +969,220 @@ msgstr ""
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:181
 #: src/lib/devices/boseBuds/boseBudsDevice.js:756
 msgid "Spatial Audio"
-msgstr ""
+msgstr "Пространственное аудио"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:338
 msgid "Enable Spatial Audio"
-msgstr ""
+msgstr "Включить пространственное аудио"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:373
 msgid "Enable in ear detection"
-msgstr ""
+msgstr "Включить автообнаружение в ухе"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:445
 #: src/preferences/devices/boseBuds/configureWindow.js:678
 msgid "Double Tap and Hold"
-msgstr ""
+msgstr "Двойное касание и удержание"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:451
 #: src/preferences/devices/nothingBuds/configureWindow.js:466
 #: src/preferences/devices/boseBuds/configureWindow.js:684
 msgid "Double Press and Hold"
-msgstr ""
+msgstr "Двойное нажатие и удержание"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:457
 #: src/preferences/devices/boseBuds/configureWindow.js:690
 msgid "Double Pinch and Hold"
-msgstr ""
+msgstr "Двойное сжатие и удержание"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:460
 msgid "Slide to Adjust"
-msgstr ""
+msgstr "Сдвиг для настройки"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:467
 msgid "Rotate"
-msgstr ""
+msgstr "Поворот"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:490
 msgid "Unknown Gesture"
-msgstr ""
+msgstr "Неизвестный жест"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:597
 #: src/preferences/devices/nothingBuds/configureWindow.js:615
 #: src/preferences/devices/boseBuds/configureWindow.js:754
 #: src/preferences/devices/boseBuds/configureWindow.js:763
 msgid "Gesture Controls"
-msgstr ""
+msgstr "Управление жестами"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:606
 msgid "Roller Gesture Control"
-msgstr ""
+msgstr "Жест колесика"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:609
 msgid "Case Gesture Control"
-msgstr ""
+msgstr "Жест на кейсе"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:612
 msgid "Slider Gesture Control"
-msgstr ""
+msgstr "Жест слайдера"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:640
 #: src/preferences/devices/galaxyBuds/configureWindow.js:467
 #: src/preferences/devices/sony/configureWindow.js:314
 #: src/preferences/devices/airpods/configureWindow.js:309
 msgid "Volume Control"
-msgstr ""
+msgstr "Управление громкостью"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:646
 msgid "ANC Type"
-msgstr ""
+msgstr "Тип шумоподавления"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:655
 msgid "Channel Hop"
-msgstr ""
+msgstr "Смена канала"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:658
 msgid "New Reporter"
-msgstr ""
+msgstr "Новый репортер"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:664
 msgid "Mic On/Off"
-msgstr ""
+msgstr "Микрофон Вкл/Выкл"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:670
 msgid "Walkie Takie"
-msgstr ""
+msgstr "Рация"
 
 #: src/preferences/devices/nothingBuds/configureWindow.js:682
 msgid "Essential Space"
-msgstr ""
+msgstr "Essential Space"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:125
 #: src/preferences/devices/airpods/configureWindow.js:119
 msgid "Choose playback behavior for Ear detection"
-msgstr ""
+msgstr "Выберите поведение воспроизведения при автообнаружении наушника"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:249
 msgid "Voice detection"
-msgstr ""
+msgstr "Обнаружение голоса"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:252
 msgid "5 seconds"
-msgstr ""
+msgstr "5 секунд"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:252
 msgid "10 seconds"
-msgstr ""
+msgstr "10 секунд"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:252
 msgid "15 seconds"
-msgstr ""
+msgstr "15 секунд"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:255
 #: src/preferences/devices/sony/configureWindow.js:133
 msgid "Duration"
-msgstr ""
+msgstr "Длительность"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:276
 msgid "Soft"
-msgstr ""
+msgstr "Мягкий"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:277
 msgid "Dynamic"
-msgstr ""
+msgstr "Динамический"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:278
 msgid "Clear"
-msgstr ""
+msgstr "Четкий"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:279
 #: src/preferences/devices/boseBuds/configureWindow.js:284
 #: src/preferences/devices/sony/configureWindow.js:218
 msgid "Treble Boost"
-msgstr ""
+msgstr "Усиление высоких частот"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:309
 msgid "Balance"
-msgstr ""
+msgstr "Баланс"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:313
 msgid "Left"
-msgstr ""
+msgstr "Левый"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:314
 msgid "Center"
-msgstr ""
+msgstr "Центр"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:315
 msgid "Right"
-msgstr ""
+msgstr "Правый"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:333
 msgid "Earbuds Controls"
-msgstr ""
+msgstr "Управление наушниками"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:339
 msgid "Media Controls (Pinch And Swipe)"
-msgstr ""
+msgstr "Управление мультимедиа (сжатие и свайп)"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:339
 msgid "Enable Touch Controls "
-msgstr ""
+msgstr "Включить сенсорное управление"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:395
 #: src/preferences/devices/boseBuds/configureWindow.js:677
 msgid "Touch and Hold"
-msgstr ""
+msgstr "Касание и удержание"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:414
 msgid "Pinch to Answer Call or End Call"
-msgstr ""
+msgstr "Сжать для ответа или завершения вызова"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:415
 msgid "Double Tap to Answer Call or End Call"
-msgstr ""
+msgstr "Двойное касание для ответа или завершения вызова"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:429
 msgid "Pinch and Hold to Decline Call"
-msgstr ""
+msgstr "Сжатие и удержание для отклонения вызова"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:430
 msgid "Touch and Hold to Decline Call"
-msgstr ""
+msgstr "Касание и удержание для отклонения вызова"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:466
 msgid "Quick Ambient Sound"
-msgstr ""
+msgstr "Быстрый окружающий звук"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:468
 #: src/lib/devices/edifierBuds/edifierBudsDevice.js:284
 msgid "Ambient Sound"
-msgstr ""
+msgstr "Окружающий звук"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:469
 #: src/preferences/devices/boseBuds/configureWindow.js:784
 msgid "Spotify"
-msgstr ""
+msgstr "Spotify"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:471
 msgid "ANC"
-msgstr ""
+msgstr "Шумоподавление (ANC)"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:487
 msgid "Left Earbud Pinch and Hold Function"
-msgstr ""
+msgstr "Функция сжатия и удержания левого наушника"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:488
 msgid "Left Earbud Touch and Hold Function"
-msgstr ""
+msgstr "Функция касания и удержания левого наушника"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:491
 msgid "Right Earbud Pinch and Hold Function"
-msgstr ""
+msgstr "Функция сжатия и удержания правого наушника"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:492
 msgid "Right Earbud Touch and Hold Function"
-msgstr ""
+msgstr "Функция касания и удержания правого наушника"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:532
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:142
@@ -1187,320 +1197,320 @@ msgstr ""
 #: src/lib/devices/googleBuds/googleBudsDevice.js:229
 #: src/lib/devices/airpods/airpodsDevice.js:203
 msgid "Adaptive"
-msgstr ""
+msgstr "Адаптивный"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:545
 msgid "Select any two toggles"
-msgstr ""
+msgstr "Выберите любые два переключателя"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:551
 msgid "Pinch and Hold Cycle for Left Earbud"
-msgstr ""
+msgstr "Цикл сжатия и удержания для левого наушника"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:552
 msgid "Pinch and hold cycles between modes (Left)"
-msgstr ""
+msgstr "Сжатие и удержание переключает режимы (слева)"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:553
 msgid "Pinch and Hold Cycle for Right Earbud"
-msgstr ""
+msgstr "Цикл сжатия и удержания для правого наушника"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:554
 msgid "Pinch and hold cycles between modes (Right)"
-msgstr ""
+msgstr "Сжатие и удержание переключает режимы (справа)"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:556
 msgid "Touch and Hold Cycle for Left Earbud"
-msgstr ""
+msgstr "Цикл касания и удержания для левого наушника"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:557
 msgid "Touch and hold cycles between modes (Left)"
-msgstr ""
+msgstr "Касание и удержание переключает режимы (слева)"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:558
 msgid "Touch and Hold Cycle for Right Earbud"
-msgstr ""
+msgstr "Цикл касания и удержания для правого наушника"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:559
 msgid "Touch and hold cycles between modes (Right)"
-msgstr ""
+msgstr "Касание и удержание переключает режимы (справа)"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:562
 msgid "Pinch and Hold Cycle"
-msgstr ""
+msgstr "Цикл сжатия и удержания"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:563
 msgid "Pinch and hold cycles between modes"
-msgstr ""
+msgstr "Сжатие и удержание переключает режимы"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:565
 msgid "Touch and Hold Cycle"
-msgstr ""
+msgstr "Цикл касания и удержания"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:566
 msgid "Touch and hold cycles between modes"
-msgstr ""
+msgstr "Касание и удержание переключает режимы"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:636
 msgid "Noise Controls With One Earbud"
-msgstr ""
+msgstr "Управление шумом с одним наушником"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:650
 msgid "Double Tap Outside Edge For Volume Controls"
-msgstr ""
+msgstr "Двойное касание края для управления громкостью"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:693
 msgid "Left Ambient Sound Volume"
-msgstr ""
+msgstr "Громкость окружающего звука (слева)"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:714
 msgid "Right Ambient Sound Volume"
-msgstr ""
+msgstr "Громкость окружающего звука (справа)"
 
 #: src/preferences/devices/galaxyBuds/configureWindow.js:735
 msgid "Ambient Sound Tone"
-msgstr ""
+msgstr "Тональность окружающего звука"
 
 #: src/preferences/devices/googleBuds/configureWindow.js:73
 msgid "Volume EQ"
-msgstr ""
+msgstr "Эквалайзер громкости"
 
 #: src/preferences/devices/googleBuds/configureWindow.js:82
 #: src/preferences/devices/airpods/configureWindow.js:323
 #: src/preferences/devices/airpods/configureWindow.js:356
 #: src/preferences/devices/airpods/configureWindow.js:374
 msgid "Default"
-msgstr ""
+msgstr "По умолчанию"
 
 #: src/preferences/devices/googleBuds/configureWindow.js:83
 msgid "Heavy bass"
-msgstr ""
+msgstr "Глубокий бас"
 
 #: src/preferences/devices/googleBuds/configureWindow.js:84
 msgid "Light bass"
-msgstr ""
+msgstr "Лёгкий бас"
 
 #: src/preferences/devices/googleBuds/configureWindow.js:86
 msgid "Vocal boost"
-msgstr ""
+msgstr "Усиление вокала"
 
 #: src/preferences/devices/googleBuds/configureWindow.js:87
 msgid "Clarity"
-msgstr ""
+msgstr "Четкость"
 
 #: src/preferences/devices/googleBuds/configureWindow.js:88
 msgid "Last saved"
-msgstr ""
+msgstr "Последний сохранённый"
 
 #: src/preferences/devices/googleBuds/configureWindow.js:130
 msgid "Low Bass"
-msgstr ""
+msgstr "Глубокий бас"
 
 #: src/preferences/devices/googleBuds/configureWindow.js:134
 msgid "Upper Treble"
-msgstr ""
+msgstr "Верхние частоты"
 
 #: src/preferences/devices/edifierBuds/configureWindow.js:67
 msgid "Settings"
-msgstr ""
+msgstr "Настройки"
 
 #: src/preferences/devices/edifierBuds/configureWindow.js:72
 msgid "Game Mode"
-msgstr ""
+msgstr "Игровой режим"
 
 #: src/preferences/devices/edifierBuds/configureWindow.js:73
 msgid "Reduce audio latency while gaming"
-msgstr ""
+msgstr "Снижает задержку звука во время игр"
 
 #: src/preferences/devices/edifierBuds/configureWindow.js:84
 msgid "In-Ear Detection"
-msgstr ""
+msgstr "Автообнаружение в ухе"
 
 #: src/preferences/devices/edifierBuds/configureWindow.js:85
 msgid "Let the earbuds detect when they are worn"
-msgstr ""
+msgstr "Позволяет наушникам определять, когда они надеты"
 
 #: src/preferences/devices/edifierBuds/configureWindow.js:94
 msgid "Auto Pause"
-msgstr ""
+msgstr "Автопауза"
 
 #: src/preferences/devices/edifierBuds/configureWindow.js:95
 msgid "Control media playback using in-ear detection"
-msgstr ""
+msgstr "Управление воспроизведением с помощью автообнаружения в ухе"
 
 #: src/preferences/devices/edifierBuds/configureWindow.js:97
 #: src/preferences/devices/boseBuds/configureWindow.js:838
 msgid "Disabled"
-msgstr ""
+msgstr "Отключено"
 
 #: src/preferences/devices/edifierBuds/configureWindow.js:98
 msgid "Pause when both removed"
-msgstr ""
+msgstr "Пауза при снятии обоих"
 
 #: src/preferences/devices/edifierBuds/configureWindow.js:99
 msgid "Pause when either removed"
-msgstr ""
+msgstr "Пауза при снятии любого"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:256
 msgid "Remember my mode"
-msgstr ""
+msgstr "Запоминать мой режим"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:283
 msgid "Bass Reducer"
-msgstr ""
+msgstr "Уменьшение басов"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:285
 msgid "Treble Reducer"
-msgstr ""
+msgstr "Уменьшение высоких частот"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:417
 msgid "Automatically switch to Transparency mode when an earbud is removed"
-msgstr ""
+msgstr "Автоматически переключаться в режим прозрачности при снятии одного наушника"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:491
 msgid "Medium"
-msgstr ""
+msgstr "Средний"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:563
 #: src/preferences/devices/sony/configureWindow.js:477
 msgid "After 5 minutes"
-msgstr ""
+msgstr "Через 5 минут"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:564
 msgid "After 20 minutes"
-msgstr ""
+msgstr "Через 20 минут"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:565
 msgid "After 40 minutes"
-msgstr ""
+msgstr "Через 40 минут"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:567
 #: src/preferences/devices/sony/configureWindow.js:480
 msgid "After 3 hours"
-msgstr ""
+msgstr "Через 3 часа"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:575
 msgid "Automatic Power Off"
-msgstr ""
+msgstr "Автоматическое выключение"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:597
 msgid "Voice Prompts"
-msgstr ""
+msgstr "Голосовые подсказки"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:612
 msgid "Enable Voice Prompts"
-msgstr ""
+msgstr "Включить голосовые подсказки"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:638
 msgid "Prompt Language"
-msgstr ""
+msgstr "Язык подсказок"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:651
 msgid "Announce Battery Level at Startup"
-msgstr ""
+msgstr "Сообщать уровень заряда при включении"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:775
 msgid "Cycle Through Modes"
-msgstr ""
+msgstr "Переключение режимов"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:781
 msgid "Switch Devices"
-msgstr ""
+msgstr "Переключение устройств"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:790
 msgid "Not Configured"
-msgstr ""
+msgstr "Не настроено"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:799
 msgid "Hear Battery Level"
-msgstr ""
+msgstr "Озвучить уровень заряда"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:805
 msgid "Increase Noise Cancellation"
-msgstr ""
+msgstr "Усилить шумоподавление"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:808
 msgid "Decrease Noise Cancellation"
-msgstr ""
+msgstr "Ослабить шумоподавление"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:811
 msgid "Toggle Wake Word"
-msgstr ""
+msgstr "Включить/выключить голосовую активацию"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:814
 msgid "Conversation Mode"
-msgstr ""
+msgstr "Режим разговора"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:823
 msgid "Hear Notifications"
-msgstr ""
+msgstr "Озвучить уведомления"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:826
 msgid "Wind Mode"
-msgstr ""
+msgstr "Режим подавления ветра"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:829
 msgid "Client Interaction"
-msgstr ""
+msgstr "Взаимодействие с клиентом"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:832
 msgid "Audio Line-In"
-msgstr ""
+msgstr "Линейный аудиовход"
 
 #: src/preferences/devices/boseBuds/configureWindow.js:835
 msgid "Speaker Link"
-msgstr ""
+msgstr "Speaker Link"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:57
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:387
 msgid "Show in toggle"
-msgstr ""
+msgstr "Показывать при переключении"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:62
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:393
 msgid "Favorite"
-msgstr ""
+msgstr "Избранное"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:74
 msgid "Preset modes cannot be deleted."
-msgstr ""
+msgstr "Предустановленные режимы нельзя удалить."
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:75
 msgid "Delete"
-msgstr ""
+msgstr "Удалить"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:86
 msgid "Mode"
-msgstr ""
+msgstr "Режим"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:122
 #: src/lib/devices/nothingBuds/nothingBudsDevice.js:393
 #: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:667
 #: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:678
 msgid "Noise Cancellation Level"
-msgstr ""
+msgstr "Уровень шумоподавления"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:158
 msgid "Wind Block"
-msgstr ""
+msgstr "Защита от ветра"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:182
 #: src/lib/devices/boseBuds/boseBudsDevice.js:760
 msgid "Still"
-msgstr ""
+msgstr "Статичный"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:182
 #: src/lib/devices/boseBuds/boseBudsDevice.js:762
 msgid "Motion"
-msgstr ""
+msgstr "В движении"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:238
 msgid "Remove Mode?"
-msgstr ""
+msgstr "Удалить режим?"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:239
 msgid "This mode will be removed."
-msgstr ""
+msgstr "Этот режим будет удален."
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:242
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:287
@@ -1508,321 +1518,323 @@ msgstr ""
 #: src/preferences/widgets/peqRowWidget.js:1122
 #: src/preferences/widgets/deviceMgmtRowWidget.js:330
 msgid "Cancel"
-msgstr ""
+msgstr "Отмена"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:243
 #: src/preferences/widgets/peqRowWidget.js:1123
 #: src/preferences/widgets/deviceMgmtRowWidget.js:331
 #: src/preferences/widgets/deviceMgmtRowWidget.js:351
 msgid "Remove"
-msgstr ""
+msgstr "Удалить"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:283
 msgid "Rename Mode?"
-msgstr ""
+msgstr "Переименовать режим?"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:284
 #, javascript-format
 msgid "Change the mode name to \"%s\"?"
-msgstr ""
+msgstr "Изменить название режима на «%s»?"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:288
 msgid "Rename"
-msgstr ""
+msgstr "Переименовать"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:401
 msgid "Edit"
-msgstr ""
+msgstr "Изменить"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:496
 msgid "Maximum 4 modes can be selected"
-msgstr ""
+msgstr "Можно выбрать максимум 4 режима"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:510
 msgid "At least 2 modes must be selected."
-msgstr ""
+msgstr "Необходимо выбрать минимум 2 режима."
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:551
 msgid "Maximum favorites limit reached."
-msgstr ""
+msgstr "Достигнут лимит избранных режимов."
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:566
 msgid "At least 2 favorites are required."
-msgstr ""
+msgstr "Требуется минимум 2 избранных режима."
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:617
 msgid "Add"
-msgstr ""
+msgstr "Добавить"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:623
 msgid "Commute"
-msgstr ""
+msgstr "Поездка"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:624
 msgid "Focus"
-msgstr ""
+msgstr "Концентрация"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:625
 msgid "Home"
-msgstr ""
+msgstr "Дом"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:626
 msgid "Music"
-msgstr ""
+msgstr "Музыка"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:628
 msgid "Relax"
-msgstr ""
+msgstr "Отдых"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:629
 msgid "Run"
-msgstr ""
+msgstr "Бег"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:630
 msgid "Walk"
-msgstr ""
+msgstr "Прогулка"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:631
 msgid "Work"
-msgstr ""
+msgstr "Работа"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:632
 msgid "Workout"
-msgstr ""
+msgstr "Тренировка"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:633
 msgid "Stereo"
-msgstr ""
+msgstr "Стерео"
 
 #: src/preferences/devices/boseBuds/modesGroupWidget.js:736
 #: src/lib/devices/boseBuds/boseBudsDevice.js:706
 msgid "Modes"
-msgstr ""
+msgstr "Режимы"
 
 #: src/preferences/devices/sony/configureWindow.js:112
 #: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:689
 #: src/lib/devices/sony/sonyDevice.js:211
 #: src/lib/devices/airpods/airpodsDevice.js:239
 msgid "Conversation Awareness"
-msgstr ""
+msgstr "Распознавание разговора"
 
 #: src/preferences/devices/sony/configureWindow.js:114
 #: src/preferences/devices/sony/configureWindow.js:292
 #: src/lib/devices/senhBuds/senhBudsDevice.js:591
 msgid "Auto"
-msgstr ""
+msgstr "Авто"
 
 #: src/preferences/devices/sony/configureWindow.js:117
 msgid "Voice Detection Sensitivity"
-msgstr ""
+msgstr "Чувствительность обнаружения голоса"
 
 #: src/preferences/devices/sony/configureWindow.js:130
 msgid "Short"
-msgstr ""
+msgstr "Короткая"
 
 #: src/preferences/devices/sony/configureWindow.js:130
 msgid "Long"
-msgstr ""
+msgstr "Длинная"
 
 #: src/preferences/devices/sony/configureWindow.js:150
 #: src/preferences/devices/sony/configureWindow.js:166
 msgid "Listening Mode"
-msgstr ""
+msgstr "Режим прослушивания"
 
 #: src/preferences/devices/sony/configureWindow.js:155
 msgid "Background Music"
-msgstr ""
+msgstr "Фоновая музыка"
 
 #: src/preferences/devices/sony/configureWindow.js:156
 msgid "Cinema"
-msgstr ""
+msgstr "Кино"
 
 #: src/preferences/devices/sony/configureWindow.js:181
 msgid "My Room"
-msgstr ""
+msgstr "Моя комната"
 
 #: src/preferences/devices/sony/configureWindow.js:182
 msgid "Living Room"
-msgstr ""
+msgstr "Гостиная"
 
 #: src/preferences/devices/sony/configureWindow.js:183
 msgid "Cafe"
-msgstr ""
+msgstr "Кафе"
 
 #: src/preferences/devices/sony/configureWindow.js:193
 msgid "Background Music Effects"
-msgstr ""
+msgstr "Эффекты фоновой музыки"
 
 #: src/preferences/devices/sony/configureWindow.js:213
 msgid "Bright"
-msgstr ""
+msgstr "Яркий"
 
 #: src/preferences/devices/sony/configureWindow.js:214
 msgid "Excited"
-msgstr ""
+msgstr "Энергичный"
 
 #: src/preferences/devices/sony/configureWindow.js:215
 msgid "Mellow"
-msgstr ""
+msgstr "Мягкий"
 
 #: src/preferences/devices/sony/configureWindow.js:216
 msgid "Relaxed"
-msgstr ""
+msgstr "Расслабленный"
 
 #: src/preferences/devices/sony/configureWindow.js:217
 msgid "Vocal"
-msgstr ""
+msgstr "Вокал"
 
 #: src/preferences/devices/sony/configureWindow.js:220
 msgid "Speech"
-msgstr ""
+msgstr "Речь"
 
 #: src/preferences/devices/sony/configureWindow.js:221
 msgid "Manual"
-msgstr ""
+msgstr "Вручную"
 
 #: src/preferences/devices/sony/configureWindow.js:222
 msgid "Custom 1"
-msgstr ""
+msgstr "Пользовательский 1"
 
 #: src/preferences/devices/sony/configureWindow.js:223
 msgid "Custom 2"
-msgstr ""
+msgstr "Пользовательский 2"
 
 #: src/preferences/devices/sony/configureWindow.js:260
 msgid "31"
-msgstr ""
+msgstr "31"
 
 #: src/preferences/devices/sony/configureWindow.js:287
 msgid "DSEE"
-msgstr ""
+msgstr "DSEE"
 
 #: src/preferences/devices/sony/configureWindow.js:291
 msgid "Enable DSEE enhancement"
-msgstr ""
+msgstr "Включить технологию улучшения звука DSEE"
 
 #: src/preferences/devices/sony/configureWindow.js:305
 msgid "Button/Touch Settings"
-msgstr ""
+msgstr "Настройки кнопок и сенсоров"
 
 #: src/preferences/devices/sony/configureWindow.js:309
 msgid "Ambient Sound Control"
-msgstr ""
+msgstr "Управление окружающим звуком"
 
 #: src/preferences/devices/sony/configureWindow.js:310
 msgid "Ambient Sound Control / Quick Access"
-msgstr ""
+msgstr "Управление окружающим звуком / Быстрый доступ"
 
 #: src/preferences/devices/sony/configureWindow.js:312
 #: src/preferences/devices/sony/configureWindow.js:313
 msgid "Playback Control"
-msgstr ""
+msgstr "Управление воспроизведением"
 
 #: src/preferences/devices/sony/configureWindow.js:315
 msgid "Not Assigned"
-msgstr ""
+msgstr "Не назначено"
 
 #: src/preferences/devices/sony/configureWindow.js:331
 msgid "Left Bud"
-msgstr ""
+msgstr "Левый наушник"
 
 #: src/preferences/devices/sony/configureWindow.js:345
 msgid "Right Bud"
-msgstr ""
+msgstr "Правый наушник"
 
 #: src/preferences/devices/sony/configureWindow.js:362
 msgid "ANC Button Configuration"
-msgstr ""
+msgstr "Конфигурация кнопки ANC"
 
 #: src/preferences/devices/sony/configureWindow.js:373
 msgid "[NC/AMB] Button Settings"
-msgstr ""
+msgstr "Настройки кнопки [NC/AMB]"
 
 #: src/preferences/devices/sony/configureWindow.js:374
 msgid "Select the modes to toggle when the button is pressed"
-msgstr ""
+msgstr "Выберите режимы для переключения при нажатии кнопки"
 
 #: src/preferences/devices/sony/configureWindow.js:392
 msgid "Notification"
-msgstr ""
+msgstr "Уведомление"
 
 #: src/preferences/devices/sony/configureWindow.js:396
 msgid "Voice Notification"
-msgstr ""
+msgstr "Голосовое уведомление"
 
 #: src/preferences/devices/sony/configureWindow.js:397
 msgid "Enable voice notification"
-msgstr ""
+msgstr "Включить голосовые уведомления"
 
 #: src/preferences/devices/sony/configureWindow.js:415
 msgid "Voice Notification Volume"
-msgstr ""
+msgstr "Громкость голосовых уведомлений"
 
 #: src/preferences/devices/sony/configureWindow.js:417
 msgid "-2"
-msgstr ""
+msgstr "-2"
 
 #: src/preferences/devices/sony/configureWindow.js:418
 msgid "-1"
-msgstr ""
+msgstr "-1"
 
 #: src/preferences/devices/sony/configureWindow.js:419
 msgid "0"
-msgstr ""
+msgstr "0"
 
 #: src/preferences/devices/sony/configureWindow.js:420
 msgid "+1"
-msgstr ""
+msgstr "+1"
 
 #: src/preferences/devices/sony/configureWindow.js:421
 msgid "+2"
-msgstr ""
+msgstr "+2"
 
 #: src/preferences/devices/sony/configureWindow.js:440
 msgid "Headset Take off"
-msgstr ""
+msgstr "Снятие наушников"
 
 #: src/preferences/devices/sony/configureWindow.js:447
 msgid "Pause when taken off"
-msgstr ""
+msgstr "Пауза при снятии"
 
 #: src/preferences/devices/sony/configureWindow.js:461
 msgid "Automatically Power Off"
-msgstr ""
+msgstr "Автоматическое выключение"
 
 #: src/preferences/devices/sony/configureWindow.js:462
 msgid "Automatically power off when not worn."
-msgstr ""
+msgstr "Автоматически выключать при отсутствии ношения."
 
 #: src/preferences/devices/airpods/configureWindow.js:136
 msgid "Volume Level"
-msgstr ""
+msgstr "Уровень громкости"
 
 #: src/preferences/devices/airpods/configureWindow.js:140
 msgid "Pause when device is not worn"
-msgstr ""
+msgstr "Пауза при снятии устройства"
 
 #: src/preferences/devices/airpods/configureWindow.js:141
 msgid "Pause playback when the device is removed,resume when it is put back on"
-msgstr ""
+msgstr "Пауза воспроизведения при снятии устройства, возобновление при надевании"
 
 #: src/preferences/devices/airpods/configureWindow.js:160
 msgid "Conversation awareness volume limit"
-msgstr ""
+msgstr "Ограничение громкости при распознавании разговора"
 
 #: src/preferences/devices/airpods/configureWindow.js:161
 msgid ""
 "Limits media volume to this percentage during conversation. Note: No change "
 "if current volume is below this level."
 msgstr ""
+"Ограничивает громкость мультимедиа до этого процента во время разговора. "
+"Примечание: громкость не изменится, если текущий уровень ниже указанного."
 
 #: src/preferences/devices/airpods/configureWindow.js:184
 msgid "Turn off listening modes"
-msgstr ""
+msgstr "Отключение режимов прослушивания"
 
 #: src/preferences/devices/airpods/configureWindow.js:188
 msgid "Allows to turn off all listening mode technology"
-msgstr ""
+msgstr "Позволяет полностью отключить технологии режимов прослушивания"
 
 #: src/preferences/devices/airpods/configureWindow.js:189
 msgid ""
@@ -1830,6 +1842,9 @@ msgid ""
 "disabled. Disabling listening modes also turns off Hearing Aid features and "
 "reduces power usage."
 msgstr ""
+"Позволяет полностью отключать режимы шумоподавления, прозрачности и "
+"адаптивный режим. Отключение режимов также отключает функции слухового "
+"аппарата и снижает энергопотребление."
 
 #: src/preferences/devices/airpods/configureWindow.js:230
 #: src/lib/devices/redmiBuds/redmiBudsDevice.js:550
@@ -1839,120 +1854,125 @@ msgstr ""
 #: src/lib/devices/googleBuds/googleBudsDevice.js:217
 #: src/lib/devices/airpods/airpodsDevice.js:202
 msgid "Transparency"
-msgstr ""
+msgstr "Прозрачность"
 
 #: src/preferences/devices/airpods/configureWindow.js:252
 msgid "Press and Hold Cycle"
-msgstr ""
+msgstr "Цикл нажатия и удержания"
 
 #: src/preferences/devices/airpods/configureWindow.js:255
 msgid "Press and hold cycles between"
-msgstr ""
+msgstr "Нажатие и удержание переключает между"
 
 #: src/preferences/devices/airpods/configureWindow.js:256
 msgid "Settings don’t reflect current state"
-msgstr ""
+msgstr "Настройки не отражают текущее состояние"
 
 #: src/preferences/devices/airpods/configureWindow.js:283
 msgid "Notification Volume"
-msgstr ""
+msgstr "Громкость уведомлений"
 
 #: src/preferences/devices/airpods/configureWindow.js:287
 msgid "Tone Volume"
-msgstr ""
+msgstr "Громкость сигналов"
 
 #: src/preferences/devices/airpods/configureWindow.js:288
 msgid "Adjust the tone volume of sound effects played by AirPods"
-msgstr ""
+msgstr "Регулировка громкости звуковых эффектов AirPods"
 
 #: src/preferences/devices/airpods/configureWindow.js:290
 msgid "15%"
-msgstr ""
+msgstr "15%"
 
 #: src/preferences/devices/airpods/configureWindow.js:291
 msgid "100%"
-msgstr ""
+msgstr "100%"
 
 #: src/preferences/devices/airpods/configureWindow.js:292
 msgid "125%"
-msgstr ""
+msgstr "125%"
 
 #: src/preferences/devices/airpods/configureWindow.js:313
 msgid "Volume Swipe"
-msgstr ""
+msgstr "Регулировка громкости свайпом"
 
 #: src/preferences/devices/airpods/configureWindow.js:314
 msgid "Enable or disable volume adjustment by swiping on earbud stems"
-msgstr ""
+msgstr "Включение или отключение регулировки громкости смахиванием по ножке наушника"
+"Включение или отключение регулировки громкости смахиванием по ножке наушника"
 
 #: src/preferences/devices/airpods/configureWindow.js:323
 #: src/preferences/devices/airpods/configureWindow.js:356
 msgid "Longer"
-msgstr ""
+msgstr "Дольше"
 
 #: src/preferences/devices/airpods/configureWindow.js:323
 #: src/preferences/devices/airpods/configureWindow.js:356
 msgid "Longest"
-msgstr ""
+msgstr "Самое долгое"
 
 #: src/preferences/devices/airpods/configureWindow.js:327
 msgid "Swipe Duration"
-msgstr ""
+msgstr "Длительность свайпа"
 
 #: src/preferences/devices/airpods/configureWindow.js:328
 msgid ""
 "To prevent unintended adjustments,select the preferred wait time between "
 "swipes"
 msgstr ""
+"Во избежание случайных срабатываний выберите желаемое время ожидания между "
+"свайпами"
 
 #: src/preferences/devices/airpods/configureWindow.js:353
 msgid "Stem and Crown Response"
-msgstr ""
+msgstr "Отклик ножки и коронки Digital Crown"
 
 #: src/preferences/devices/airpods/configureWindow.js:360
 msgid "Press Speed"
-msgstr ""
+msgstr "Скорость нажатия"
 
 #: src/preferences/devices/airpods/configureWindow.js:361
 msgid ""
 "Adjust how quickly you must double or triple-press the stem or Digital Crown "
 "before an action occurs"
 msgstr ""
+"Настройте скорость двойного или тройного нажатия на ножку или коронку "
+"Digital Crown для выполнения действия"
 
 #: src/preferences/devices/airpods/configureWindow.js:374
 msgid "Shorter"
-msgstr ""
+msgstr "Короче"
 
 #: src/preferences/devices/airpods/configureWindow.js:374
 msgid "Shortest"
-msgstr ""
+msgstr "Самое короткое"
 
 #: src/preferences/devices/airpods/configureWindow.js:377
 msgid "Press and Hold Duration"
-msgstr ""
+msgstr "Длительность нажатия и удержания"
 
 #: src/preferences/devices/airpods/configureWindow.js:378
 msgid "Set how long you need to press and hold before an action occurs"
-msgstr ""
+msgstr "Настройте, как долго нужно удерживать нажатие для выполнения действия"
 
 #: src/preferences/widgets/ringMyBudsRow.js:22
 msgid "Find my earbuds"
-msgstr ""
+msgstr "Найти мои наушники"
 
 #: src/preferences/widgets/ringMyBudsRow.js:33
 #: src/preferences/widgets/ringMyBudsRow.js:54
 #: src/preferences/widgets/ringMyBudsRow.js:98
 #: src/preferences/widgets/ringMyBudsRow.js:143
 msgid "Play"
-msgstr ""
+msgstr "Воспроизвести"
 
 #: src/preferences/widgets/ringMyBudsRow.js:95
 msgid "Stop"
-msgstr ""
+msgstr "Остановить"
 
 #: src/preferences/widgets/ringMyBudsRow.js:134
 msgid "Continue?"
-msgstr ""
+msgstr "Продолжить?"
 
 #: src/preferences/widgets/ringMyBudsRow.js:136
 msgid ""
@@ -1960,288 +1980,293 @@ msgid ""
 "before you continue. A loud sound will be played which could be "
 "uncomfortable for anyone wearing them."
 msgstr ""
+"Ваши наушники могут использоваться. Обязательно извлеките их из ушей перед "
+"продолжением. Будет воспроизведен громкий звук, который может быть неприятен "
+"для того, на ком надеты наушники."
 
 #: src/preferences/widgets/iconSelectorWidget.js:51
 #: src/preferences/widgets/iconSelectorWidget.js:69
 msgid "Device information"
-msgstr ""
+msgstr "Информация об устройстве"
 
 #: src/preferences/widgets/iconSelectorWidget.js:103
 msgid "Mac Address"
-msgstr ""
+msgstr "MAC-адрес"
 
 #: src/preferences/widgets/iconSelectorWidget.js:106
 msgid "Firmware Version"
-msgstr ""
+msgstr "Версия прошивки"
 
 #: src/preferences/widgets/iconSelectorWidget.js:116
 #: src/preferences/widgets/iconSelectorWidget.js:149
 msgid "Serial Number"
-msgstr ""
+msgstr "Серийный номер"
 
 #: src/preferences/widgets/peqRowWidget.js:631
 msgid "Peak"
-msgstr ""
+msgstr "Пиковый"
 
 #: src/preferences/widgets/peqRowWidget.js:632
 msgid "Low Pass Filter"
-msgstr ""
+msgstr "Фильтр низких частот (ФНЧ)"
 
 #: src/preferences/widgets/peqRowWidget.js:633
 msgid "High Pass Filter"
-msgstr ""
+msgstr "Фильтр высоких частот (ФВЧ)"
 
 #: src/preferences/widgets/peqRowWidget.js:634
 msgid "Low Shelf Filter"
-msgstr ""
+msgstr "НЧ шельфовый фильтр"
 
 #: src/preferences/widgets/peqRowWidget.js:635
 msgid "High Shelf Filter"
-msgstr ""
+msgstr "ВЧ шельфовый фильтр"
 
 #: src/preferences/widgets/peqRowWidget.js:641
 msgid "Frequency"
-msgstr ""
+msgstr "Частота"
 
 #: src/preferences/widgets/peqRowWidget.js:649
 msgid "Quality Factor"
-msgstr ""
+msgstr "Добротность (Q)"
 
 #: src/preferences/widgets/peqRowWidget.js:657
 msgid "Gain"
-msgstr ""
+msgstr "Усиление"
 
 #: src/preferences/widgets/peqRowWidget.js:782
 msgid "Bypass"
-msgstr ""
+msgstr "Обход"
 
 #: src/preferences/widgets/peqRowWidget.js:790
 #, javascript-format
 msgid "%d Hz,  %s dB,  Q: %s"
-msgstr ""
+msgstr "%d Гц,  %s дБ,  Q: %s"
 
 #: src/preferences/widgets/peqRowWidget.js:931
 msgid "Pre Amp Gain"
-msgstr ""
+msgstr "Усиление предусилителя"
 
 #: src/preferences/widgets/peqRowWidget.js:963
 msgid "Add Band"
-msgstr ""
+msgstr "Добавить полосу"
 
 #: src/preferences/widgets/peqRowWidget.js:969
 msgid "Remove Last Band"
-msgstr ""
+msgstr "Удалить последнюю полосу"
 
 #: src/preferences/widgets/peqRowWidget.js:1105
 #, javascript-format
 msgid "Band %d"
-msgstr ""
+msgstr "Полоса %d"
 
 #: src/preferences/widgets/peqRowWidget.js:1118
 msgid "Remove Band?"
-msgstr ""
+msgstr "Удалить полосу?"
 
 #: src/preferences/widgets/peqRowWidget.js:1119
 #, javascript-format
 msgid "Band %d will be removed."
-msgstr ""
+msgstr "Полоса %d будет удалена."
 
 #: src/preferences/widgets/peqRowWidget.js:1340
 msgid "Show"
-msgstr ""
+msgstr "Показать"
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:30
 msgid "Connection Manager"
-msgstr ""
+msgstr "Менеджер подключений"
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:37
 msgid "Pairing Mode"
-msgstr ""
+msgstr "Режим сопряжения"
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:39
 msgid "Enable Pairing Mode"
-msgstr ""
+msgstr "Включить режим сопряжения"
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:40
 msgid "Allow a new Bluetooth device to pair."
-msgstr ""
+msgstr "Разрешить сопряжение новому Bluetooth-устройству."
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:77
 msgid "Playback Device"
-msgstr ""
+msgstr "Устройство воспроизведения"
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:78
 msgid "Lock Playback Device"
-msgstr ""
+msgstr "Зафиксировать устройство воспроизведения"
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:79
 msgid ""
 "Prevent playback from switching to another connected device while the set "
 "playback device is streaming."
 msgstr ""
+"Запретить переключение воспроизведения на другое подключенное устройство во "
+"время потоковой передачи."
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:95
 msgid "Connected"
-msgstr ""
+msgstr "Подключено"
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:96
 msgid "Paired"
-msgstr ""
+msgstr "Сопряжено"
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:97
 msgid "No device connected"
-msgstr ""
+msgstr "Нет подключенных устройств"
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:98
 msgid "No additional device paired"
-msgstr ""
+msgstr "Нет других сопряженных устройств"
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:162
 #: src/preferences/widgets/deviceMgmtRowWidget.js:250
 msgid "Loading Device Information..."
-msgstr ""
+msgstr "Загрузка информации об устройстве..."
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:164
 #: src/preferences/widgets/deviceMgmtRowWidget.js:252
 msgid "(This Device)"
-msgstr ""
+msgstr "(Это устройство)"
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:299
 msgid "Connection Limit Reached"
-msgstr ""
+msgstr "Достигнут лимит подключений"
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:300
 msgid "Disconnect another device before connecting this device."
-msgstr ""
+msgstr "Отключите другое устройство перед подключением этого устройства."
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:303
 msgid "OK"
-msgstr ""
+msgstr "ОК"
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:326
 msgid "Remove Device?"
-msgstr ""
+msgstr "Удалить устройство?"
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:327
 msgid "The device will be removed from the paired devices list."
-msgstr ""
+msgstr "Устройство будет удалено из списка сопряженных устройств."
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:348
 msgid "Set as Playback Device"
-msgstr ""
+msgstr "Назначить устройством воспроизведения"
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:349
 msgid "Connect"
-msgstr ""
+msgstr "Подключить"
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:350
 msgid "Disconnect"
-msgstr ""
+msgstr "Отключить"
 
 #: src/preferences/widgets/deviceMgmtRowWidget.js:474
 msgid "Manage Devices"
-msgstr ""
+msgstr "Управление устройствами"
 
 #: src/lib/devices/senhBuds/senhBudsDevice.js:582
 #: src/lib/devices/redmiBuds/redmiBudsDevice.js:624
 msgid "Noise Level"
-msgstr ""
+msgstr "Уровень шума"
 
 #: src/lib/devices/senhBuds/senhBudsDevice.js:590
 msgid "Max"
-msgstr ""
+msgstr "Макс"
 
 #: src/lib/devices/senhBuds/senhBudsDevice.js:601
 msgid "Anti Wind"
-msgstr ""
+msgstr "Защита от ветра"
 
 #: src/lib/devices/redmiBuds/redmiBudsDevice.js:611
 msgid "Noise Cancellation Strength"
-msgstr ""
+msgstr "Сила шумоподавления"
 
 #: src/lib/devices/redmiBuds/redmiBudsDevice.js:633
 msgid "Regular"
-msgstr ""
+msgstr "Обычный"
 
 #: src/lib/devices/redmiBuds/redmiBudsDevice.js:655
 msgid "Transparency Strength"
-msgstr ""
+msgstr "Интенсивность прозрачности"
 
 #: src/lib/devices/nothingBuds/nothingBudsDevice.js:429
 msgid "Personalised ANC"
-msgstr ""
+msgstr "Персонализированный ANC"
 
 #: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:665
 #: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:675
 #: src/lib/devices/sony/sonyDevice.js:190
 #: src/lib/devices/airpods/airpodsDevice.js:233
 msgid "Ambient Level"
-msgstr ""
+msgstr "Уровень окружающего звука"
 
 #: src/lib/devices/galaxyBuds/galaxyBudsDevice.js:671
 #: src/lib/devices/sony/sonyDevice.js:193
 #: src/lib/devices/sony/sonyDevice.js:195
 #: src/lib/devices/sony/sonyDevice.js:199
 msgid "Focus on Voice"
-msgstr ""
+msgstr "Фокус на голосе"
 
 #: src/lib/devices/boseBuds/boseBudsDevice.js:678
 msgid "Wind"
-msgstr ""
+msgstr "Ветер"
 
 #: src/lib/devices/sony/sonyDevice.js:193
 #: src/lib/devices/sony/sonyDevice.js:195
 msgid "Auto Ambient"
-msgstr ""
+msgstr "Автоматический окружающий звук"
 
 #: src/lib/devices/sony/sonyDevice.js:196
 msgid "Auto Ambient Sensitivity"
-msgstr ""
+msgstr "Чувствительность авто-окружающего звука"
 
 #: src/lib/devices/notifier.js:25
 msgid "AirPods / Beats Bluetooth audio devices"
-msgstr ""
+msgstr "Bluetooth-аудиоустройства AirPods / Beats"
 
 #: src/lib/devices/notifier.js:27
 msgid "Sony Bluetooth audio devices"
-msgstr ""
+msgstr "Bluetooth-аудиоустройства Sony"
 
 #: src/lib/devices/notifier.js:29
 msgid "Samsung Galaxy Bluetooth audio devices"
-msgstr ""
+msgstr "Bluetooth-аудиоустройства Samsung Galaxy"
 
 #: src/lib/devices/notifier.js:31
 msgid "Nothing / CMF Bluetooth audio devices"
-msgstr ""
+msgstr "Bluetooth-аудиоустройства Nothing / CMF"
 
 #: src/lib/devices/notifier.js:33
 msgid "Google Pixel Buds Bluetooth audio devices"
-msgstr ""
+msgstr "Bluetooth-аудиоустройства Google Pixel Buds"
 
 #: src/lib/devices/notifier.js:35
 msgid "Redmi / Xiaomi Bluetooth audio devices"
-msgstr ""
+msgstr "Bluetooth-аудиоустройства Redmi / Xiaomi"
 
 #: src/lib/devices/notifier.js:37
 msgid "Sennheiser Bluetooth audio devices"
-msgstr ""
+msgstr "Bluetooth-аудиоустройства Sennheiser"
 
 #: src/lib/devices/notifier.js:39
 msgid "Bose Bluetooth audio devices"
-msgstr ""
+msgstr "Bluetooth-аудиоустройства Bose"
 
 #: src/lib/devices/notifier.js:41
 msgid "Edifier Bluetooth audio devices"
-msgstr ""
+msgstr "Bluetooth-аудиоустройства Edifier"
 
 #: src/lib/devices/notifier.js:43
 msgid "Google Fast Pair Bluetooth audio devices"
-msgstr ""
+msgstr "Bluetooth-аудиоустройства Google Fast Pair"
 
 #: src/lib/devices/notifier.js:49
 #, javascript-format
 msgid "Could not access advanced features for %s."
-msgstr ""
+msgstr "Не удалось получить доступ к расширенным функциям для %s."
 
 #: src/lib/devices/notifier.js:52
 #, javascript-format
@@ -2249,3 +2274,197 @@ msgid ""
 "Another app or session is already using the Bluetooth socket/profile on %s. "
 "Close any other apps using this device, then restart this app."
 msgstr ""
+
+#~ msgid "Personalized ANC"
+#~ msgstr "Персонализированный ANC"
+
+#~ msgid "AirPods / Beats"
+#~ msgstr "AirPods / Beats"
+
+#~ msgid "Sony"
+#~ msgstr "Sony"
+
+#~ msgid "Samsung Galaxy"
+#~ msgstr "Samsung Galaxy"
+
+#~ msgid "Nothing / CMF"
+#~ msgstr "Nothing / CMF"
+
+#~ msgid "Google Pixel Buds"
+#~ msgstr "Google Pixel Buds"
+
+#~ msgid "Redmi / Xiaomi"
+#~ msgstr "Redmi / Xiaomi"
+
+#~ msgid "Sennheiser"
+#~ msgstr "Sennheiser"
+
+#~ msgid "Bose"
+#~ msgstr "Bose"
+
+#~ msgid "Edifier"
+#~ msgstr "Edifier"
+
+#~ msgid "Google Fast Pair"
+#~ msgstr "Google Fast Pair"
+
+#, javascript-format
+#~ msgid "Could not access advanced features for %s Bluetooth audio devices."
+#~ msgstr ""
+#~ "Не удалось получить доступ к расширенным функциям для аудиоустройств "
+#~ "Bluetooth %s."
+
+#, javascript-format
+#~ msgid ""
+#~ "Another app or session is already using the Bluetooth socket/profile for "
+#~ "%s Bluetooth audio devices. Close any other apps using this device, then "
+#~ "restart this app."
+#~ msgstr ""
+#~ "Другое приложение или сессия уже использует Bluetooth-сокет/профиль для "
+#~ "аудиоустройств Bluetooth %s. Закройте другие приложения, использующие это "
+#~ "устройство, затем перезапустите данное приложение."
+
+#~ msgid "Choose Playback Behavior for In-Ear Detection"
+#~ msgstr "Выберите поведение воспроизведения при автообнаружении в ухе"
+
+#~ msgid "Lower volume during conversation awareness"
+#~ msgstr "Снижать громкость при распознавании разговора"
+
+#~ msgid "Automatically lower the volume when conversation awareness is active"
+#~ msgstr ""
+#~ "Автоматически снижать громкость во время активности режима распознавания "
+#~ "разговора"
+
+#~ msgid "Adjust the volume of audio cues"
+#~ msgstr "Регулировка громкости звуковых сигналов"
+
+#~ msgid "Change the sound signature"
+#~ msgstr "Изменить характер звучания"
+
+#~ msgid "On Head Detection"
+#~ msgstr "Автообнаружение на голове"
+
+#~ msgid "Enable features based on wearing detection"
+#~ msgstr "Включение функций на основе датчиков ношения"
+
+#~ msgid "Answer Calls Automatically"
+#~ msgstr "Автоответ на вызовы"
+
+#~ msgid "Answer calls when the earbuds are worn"
+#~ msgstr "Принимать вызовы при надевании наушников"
+
+#~ msgid "Automatic Transparency Mode"
+#~ msgstr "Автоматический режим прозрачности"
+
+#~ msgid "Switch to Transparency mode when an earbud is removed"
+#~ msgstr "Переключаться в режим прозрачности при снятии одного наушника"
+
+#~ msgid "Choose Playback Behavior for On-Head Detection"
+#~ msgstr "Выберите поведение воспроизведения при автообнаружении на голове"
+
+#~ msgid "Adjust your voice feedback level"
+#~ msgstr "Регулировка уровня слышимости собственного голоса"
+
+#~ msgid "Automatic Power Off Duration"
+#~ msgstr "Время до автоматического выключения"
+
+#~ msgid "Automatically power off when not worn"
+#~ msgstr "Автоматически выключать при отсутствии ношения"
+
+#~ msgid "Voice Prompt Settings"
+#~ msgstr "Настройки голосовых подсказок"
+
+#~ msgid "Enable voice prompts for guidance and status updates"
+#~ msgstr "Включение голосовых подсказок о состоянии устройства"
+
+#~ msgid "Select the language for voice prompts"
+#~ msgstr "Выберите язык голосовых подсказок"
+
+#~ msgid "Announce the battery level when powered on"
+#~ msgstr "Озвучивать уровень заряда батареи при включении"
+
+#~ msgid "Preset modes cannot be deleted"
+#~ msgstr "Предустановленные режимы нельзя удалить"
+
+#~ msgid "Immersive Audio"
+#~ msgstr "Пространственное аудио"
+
+#~ msgid "At least 2 modes must be selected"
+#~ msgstr "Необходимо выбрать минимум 2 режима"
+
+#~ msgid "Maximum favorites limit reached"
+#~ msgstr "Достигнут лимит избранных режимов"
+
+#~ msgid "Reduces latency and enhances in-game audio"
+#~ msgstr "Снижает задержку и оптимизирует звук в играх"
+
+#~ msgid "Choose Playback Behavior for Ear Detection"
+#~ msgstr "Выберите поведение воспроизведения при автообнаружении наушника"
+
+#~ msgid "Vocal Boost"
+#~ msgstr "Усиление вокала"
+
+#~ msgid "Last Saved"
+#~ msgstr "Последний сохраненный"
+
+#~ msgid "Vocals"
+#~ msgstr "Вокал"
+
+#~ msgid "Bass Enhancement"
+#~ msgstr "Усиление басов"
+
+#~ msgid "Enhances bass in real time"
+#~ msgstr "Усиливает низкие частоты в реальном времени"
+
+#~ msgid "Bass Enhancement Level"
+#~ msgstr "Уровень усиления басов"
+
+#~ msgid "Add depth for a more immersive experience"
+#~ msgstr "Добавляет глубину для эффекта погружения"
+
+#~ msgid "Walkie-Talkie"
+#~ msgstr "Рация"
+
+#~ msgid "Automatically adjust sound to your ear shape"
+#~ msgstr "Автоматически подстраивать звук под форму уха"
+
+#~ msgid "Sound Customization"
+#~ msgstr "Настройка звука"
+
+#~ msgid "Customize your listening experience"
+#~ msgstr "Персонализируйте качество прослушивания"
+
+#~ msgid "Blend channels for natural sound"
+#~ msgstr "Смешивание каналов для естественного звучания"
+
+#~ msgid "Make phone calls sound more natural"
+#~ msgstr "Делает звучание голоса при телефонных звонках более естественным"
+
+#~ msgid "Pause Media in Transparency Mode"
+#~ msgstr "Пауза воспроизведения в режиме прозрачности"
+
+#~ msgid "Automatically pause media when transparency mode is enabled"
+#~ msgstr ""
+#~ "Автоматически ставить воспроизведение на паузу при включении режима "
+#~ "прозрачности"
+
+#~ msgid "Voice Prompt"
+#~ msgstr "Голосовая подсказка"
+
+#~ msgid "Voice Prompt Volume"
+#~ msgstr "Громкость голосовых подсказок"
+
+#~ msgid "Adjust the volume of voice prompts"
+#~ msgstr "Регулировка громкости голосовых подсказок"
+
+#~ msgid "Headset Take Off"
+#~ msgstr "Снятие наушников"
+
+#~ msgid "Manage Device Connections"
+#~ msgstr "Управление подключениями устройств"
+
+#~ msgid "MAC Address"
+#~ msgstr "MAC-адрес"
+
+#~ msgid "Ring your earbuds to locate them"
+#~ msgstr "Воспроизвести звуковой сигнал на наушниках для их поиска"

--- a/src/app.js
+++ b/src/app.js
@@ -30,7 +30,24 @@ const SIGINT = 2;
 const SIGTERM = 15;
 
 const AppId = pkg.name; // eslint-disable-line no-undef
-const dataDir = pkg.datadir; // eslint-disable-line no-undef
+
+function resolveDataDir() {
+    const installed = pkg.datadir; // eslint-disable-line no-undef
+    const installedIcons = GLib.build_filenamev([installed, 'icons']);
+    if (GLib.file_test(installedIcons, GLib.FileTest.IS_DIR))
+        return installed;
+
+    const srcRoot = GLib.getenv('MESON_SOURCE_ROOT');
+    if (srcRoot) {
+        const srcPath = GLib.build_filenamev([srcRoot, 'src']);
+        if (GLib.file_test(GLib.build_filenamev([srcPath, 'icons']), GLib.FileTest.IS_DIR))
+            return srcPath;
+    }
+
+    return installed;
+}
+
+const dataDir = resolveDataDir();
 
 export const BudsLinkApplication = GObject.registerClass({
     GTypeName: 'BudsLinkApplication',

--- a/src/appLibs/widgets/settingsButton.js
+++ b/src/appLibs/widgets/settingsButton.js
@@ -9,12 +9,14 @@ import {gettext as _} from 'gettext';
 
 const MODE_KEY = 'dark-mode';
 const ACCENT_KEY = 'accent-color';
+const LANG_KEY = 'language';
 
 const MODE_SYSTEM = 'system';
 const MODE_LIGHT = 'light';
 const MODE_DARK = 'dark';
 
 const ACCENT_SYSTEM = 'system';
+const LANG_SYSTEM = 'system';
 
 export const SettingsButton = GObject.registerClass(
 class SettingsButton extends Gtk.MenuButton {
@@ -70,6 +72,13 @@ class SettingsButton extends Gtk.MenuButton {
             _('Accent Color'),
             true,
             btn => this._openSubPopover(() => this._createAccentColorPopover(), btn)
+        ));
+
+        box.append(this._createRow(
+            'preferences-desktop-locale-symbolic',
+            _('Language'),
+            true,
+            btn => this._openSubPopover(() => this._createLanguagePopover(), btn)
         ));
 
         box.append(this._createRow(
@@ -220,6 +229,89 @@ class SettingsButton extends Gtk.MenuButton {
         }
 
         popover.set_child(box);
+        return popover;
+    }
+
+    _getLanguage() {
+        const v = this._settings.get_string(LANG_KEY);
+        return v || LANG_SYSTEM;
+    }
+
+    _createLanguagePopover() {
+        const current = this._getLanguage();
+
+        const popover = new Gtk.Popover({
+            has_arrow: true,
+            position: this._popPosition,
+            cascade_popdown: true,
+        });
+
+        const scrolled = new Gtk.ScrolledWindow({
+            hscrollbar_policy: Gtk.PolicyType.NEVER,
+            vscrollbar_policy: Gtk.PolicyType.AUTOMATIC,
+            max_content_height: 360,
+            propagate_natural_height: true,
+        });
+
+        const box = new Gtk.Box({
+            orientation: Gtk.Orientation.VERTICAL,
+            spacing: 4,
+            margin_top: 6,
+            margin_bottom: 6,
+            margin_start: 6,
+            margin_end: 6,
+        });
+
+        const languages = [
+            {code: LANG_SYSTEM, name: _('System Default')},
+            {code: 'en', name: 'English'},
+            {code: 'en_GB', name: 'English (UK)'},
+            {code: 'ru', name: 'Русский'},
+            {code: 'cs', name: 'Čeština'},
+            {code: 'de', name: 'Deutsch'},
+            {code: 'de_CH', name: 'Deutsch (Schweiz)'},
+            {code: 'fr', name: 'Français'},
+            {code: 'id', name: 'Bahasa Indonesia'},
+            {code: 'it', name: 'Italiano'},
+            {code: 'ko', name: '한국어'},
+            {code: 'nl', name: 'Nederlands'},
+            {code: 'oc', name: 'Occitan'},
+            {code: 'pt_BR', name: 'Português (Brasil)'},
+        ];
+
+        for (const lang of languages) {
+            const isSelected = current === lang.code;
+            const row = this._createCheckRow(lang.name, isSelected);
+            row.connect('clicked', () => {
+                popover.popdown();
+                this._mainPopover.popdown();
+
+                if (current === lang.code)
+                    return;
+
+                const dialog = new Adw.AlertDialog({
+                    heading: _('Language'),
+                    body: _('Restart required to apply language change'),
+                    close_response: 'cancel',
+                });
+                dialog.add_response('cancel', _('Cancel'));
+                dialog.add_response('ok', _('OK'));
+                dialog.set_default_response('ok');
+                dialog.set_response_appearance('ok', Adw.ResponseAppearance.SUGGESTED);
+                dialog.choose(this.get_root(), null, (dialog, res) => {
+                    try {
+                        if (dialog.choose_finish(res) === 'ok')
+                            this._settings.set_string(LANG_KEY, lang.code);
+                    } catch (e) {
+                        // ignore dialog close errors
+                    }
+                });
+            });
+            box.append(row);
+        }
+
+        scrolled.set_child(box);
+        popover.set_child(scrolled);
         return popover;
     }
 

--- a/src/io.github.maniacx.BudsLink.js
+++ b/src/io.github.maniacx.BudsLink.js
@@ -1,5 +1,6 @@
 #!@GJS@ -m
 import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
 
 imports.package.init({
     name: '@PACKAGE_NAME@',
@@ -7,6 +8,12 @@ imports.package.init({
     prefix: '@PREFIX@',
     libdir: '@LIBDIR@',
 });
+
+const settings = new Gio.Settings({schema_id: '@PACKAGE_NAME@'});
+const lang = settings.get_string('language');
+if (lang && lang !== 'system')
+    GLib.setenv('LANGUAGE', lang, true);
+
 imports.package.initGettext();
 
 const loop = new GLib.MainLoop(null, false);


### PR DESCRIPTION
Add a language selector with English, Russian, and non-empty translation catalogs, including partially translated locales. Persist the selection before gettext initialization, add a complete Russian translation credited to Andrey Sychin, ensure GSettings schema compilation, and preserve icon loading in development builds.