### PR TITLE
App metadata: update translation link

### DIFF
--- a/data/io.github.maniacx.BudsLink.metainfo.xml
+++ b/data/io.github.maniacx.BudsLink.metainfo.xml
@@ -54,7 +54,7 @@
   <url type="homepage">https://maniacx.github.io/BudsLink/</url>
   <url type="bugtracker">https://github.com/maniacx/BudsLink/issues</url>
   <url type="help">https://maniacx.github.io/BudsLink/</url>
-  <url type="translate">https://maniacx.github.io/BudsLink/translation</url>
+  <url type="translate">https://hosted.weblate.org/engage/budslink/</url>
   <url type="vcs-browser">https://github.com/maniacx/BudsLink/</url>
   <content_rating type="oars-1.1" />
   <launchable type="desktop-id">@APP_ID@.desktop</launchable>


### PR DESCRIPTION
Hello,
foremost congrats to be out of trial mode on Weblate!
And to make this shift visible also for translators (and to shorten pah to it to be actionable for them), proposing change of translation URL directly to engage page on Weblate.
This way, users will notice it in app catalogue and it's better chance, they will start to translate this way (as opposite to be routed to docs, where link to weblate could be - more clicks, less chance to gain conversions from leads ;-) ).

Thanks :-)