### PR TITLE
feat: add "Run in Background" option for non-GNOME desktops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build-dir
 .flatpak-builder
 localdata
 repo
+data/gschemas.compiled
+subprojects/.wraplock

--- a/data/io.github.maniacx.BudsLink.gschema.xml
+++ b/data/io.github.maniacx.BudsLink.gschema.xml
@@ -10,6 +10,9 @@
         <key name="logging-enabled" type="b">
             <default>false</default>
         </key>
+        <key name="run-in-background" type="b">
+            <default>false</default>
+        </key>
         <key name="attenuated-on-destroy-info" type="as">
             <default>[]</default>
         </key>

--- a/src/app.js
+++ b/src/app.js
@@ -42,6 +42,7 @@ export const BudsLinkApplication = GObject.registerClass({
         });
 
         this._isServiceHeld = false;
+        this._isBackgroundHeld = false;
 
         this._log = createLogger('Main');
 
@@ -156,6 +157,24 @@ export const BudsLinkApplication = GObject.registerClass({
         this._client = new BluetoothClient();
         this._deviceManager = new EnhancedDeviceSupportManager(this);
         this._initialize();
+
+        this._applyRunInBackground();
+        this._bgSettingsId = this.settings.connect('changed::run-in-background',
+            () => this._applyRunInBackground());
+    }
+
+    _applyRunInBackground() {
+        const enabled = this.settings.get_boolean('run-in-background');
+
+        if (enabled && !this._isBackgroundHeld) {
+            this._isBackgroundHeld = true;
+            this.hold();
+            this._log.info('run-in-background enabled');
+        } else if (!enabled && this._isBackgroundHeld) {
+            this._isBackgroundHeld = false;
+            this.release();
+            this._log.info('run-in-background disabled');
+        }
     }
 
     _onActivate() {
@@ -313,6 +332,16 @@ export const BudsLinkApplication = GObject.registerClass({
         if (this._sigtermId) {
             GLib.Source.remove(this._sigtermId);
             this._sigtermId = 0;
+        }
+
+        if (this._bgSettingsId && this.settings) {
+            this.settings.disconnect(this._bgSettingsId);
+            this._bgSettingsId = 0;
+        }
+
+        if (this._isBackgroundHeld) {
+            this.release();
+            this._isBackgroundHeld = false;
         }
 
         this._themeManager?.destroy();

--- a/src/appLibs/widgets/settingsButton.js
+++ b/src/appLibs/widgets/settingsButton.js
@@ -80,6 +80,13 @@ class SettingsButton extends Gtk.MenuButton {
         ));
 
         box.append(this._createRow(
+            'bbm-mode-run-symbolic',
+            _('Run in Background'),
+            true,
+            btn => this._openSubPopover(() => this._createRunInBackgroundPopover(), btn)
+        ));
+
+        box.append(this._createRow(
             'bbm-extension-symbolic',
             _('BudsLink Companion'),
             true,
@@ -291,6 +298,43 @@ class SettingsButton extends Gtk.MenuButton {
 
             row.connect('clicked', () => {
                 this._settings.set_boolean('logging-enabled', value);
+                popover.popdown();
+                this._mainPopover.popdown();
+            });
+
+            box.append(row);
+        };
+
+        add(_('On'), true);
+        add(_('Off'), false);
+
+        popover.set_child(box);
+        return popover;
+    }
+
+    _createRunInBackgroundPopover() {
+        const enabled = this._settings.get_boolean('run-in-background');
+
+        const popover = new Gtk.Popover({
+            has_arrow: true,
+            position: this._popPosition,
+            cascade_popdown: true,
+        });
+
+        const box = new Gtk.Box({
+            orientation: Gtk.Orientation.VERTICAL,
+            spacing: 6,
+            margin_top: 6,
+            margin_bottom: 6,
+            margin_start: 6,
+            margin_end: 6,
+        });
+
+        const add = (label, value) => {
+            const row = this._createCheckRow(label, enabled === value);
+
+            row.connect('clicked', () => {
+                this._settings.set_boolean('run-in-background', value);
                 popover.popdown();
                 this._mainPopover.popdown();
             });


### PR DESCRIPTION
## Problem

On non-GNOME desktops (KDE, XFCE, Cinnamon, etc.) the app exits when the
window is closed, because there is no shell extension / D-Bus client to
call `HoldService` and keep the GApplication alive via `hold()`.

The existing D-Bus `HoldService`/`ReleaseService` heartbeat mechanism is
designed for the GNOME Shell extension companion — it has no equivalent
on other DEs, so all device functionality (battery monitoring, ANC
control, touch actions) is lost as soon as the user closes the window.

## Solution

Add a user-facing **"Run in Background"** toggle in the app settings menu
that calls `GApplication.hold()` directly, keeping the process alive
after the window is closed — independent of any D-Bus client.

This is a standard GLib/GIO mechanism and works on **any desktop
environment**, not just GNOME.

### Changes

- **`data/io.github.maniacx.BudsLink.gschema.xml`** — new boolean key
  `run-in-background` (default `false`)
- **`src/app.js`** — `_applyRunInBackground()` applies `hold()`/`release()`
  based on the setting; listens to `changed::run-in-background` so the
  change takes effect immediately without restart; cleanup in `destroy()`
- **`src/appLibs/widgets/settingsButton.js`** — new "Run in Background"
  menu row (icon `bbm-mode-run-symbolic`) with On/Off sub-popover,
  matching the existing "Packet Logging" UI pattern

### Compatibility

| Desktop | Default (off) | Option ON |
|---|---|---|
| GNOME + extension | unchanged (D-Bus hold) | works, additive hold (no conflict) |
| KDE / XFCE / Cinnamon | app exits on close (current behavior) | stays alive in background |
| GNOME without extension | app exits on close | stays alive in background |

- **Default is `false`** — zero behavior change for existing users
- The background `hold()` is **additive** to the existing D-Bus
  `HoldService` mechanism — they use separate flags
  (`_isBackgroundHeld` vs `_isServiceHeld`) and do not interfere

### How to test

1. Launch BudsLink on a non-GNOME desktop (e.g. KDE Plasma)
2. Open Settings → **Run in Background** → **On**
3. Close the window
4. Verify the process is still alive: `pgrep -fa budslink`
5. Verify device functionality still works (battery, ANC, etc.)
6. Open Settings → **Run in Background** → **Off**
7. Close the window → process exits within a few seconds