### PR TITLE
feat(devices): add 1MORE SonoFlow (HC905) support via SPP

### DIFF
--- a/data/io.github.maniacx.BudsLink.gschema.xml
+++ b/data/io.github.maniacx.BudsLink.gschema.xml
@@ -40,6 +40,9 @@
         <key name="edifier-buds-list" type="as">
             <default>[]</default>
         </key>
+        <key name="one-more-buds-list" type="as">
+            <default>[]</default>
+        </key>
         <key name="gfps-list" type="as">
             <default>[]</default>
         </key>

--- a/src/app.js
+++ b/src/app.js
@@ -151,6 +151,7 @@ export const BudsLinkApplication = GObject.registerClass({
         this.senhBudsEnabled = true;
         this.boseBudsEnabled = true;
         this.edifierBudsEnabled = true;
+        this.oneMoreBudsEnabled = true;
         this.gfpsEnabled = true;
 
         this._client = new BluetoothClient();

--- a/src/appLibs/confirueWindowlauncher.js
+++ b/src/appLibs/confirueWindowlauncher.js
@@ -8,6 +8,7 @@ import * as RedmiBuds from '../preferences/devices/redmiBuds/configureWindow.js'
 import * as SenhBuds from '../preferences/devices/senhBuds/configureWindow.js';
 import * as BoseBuds from '../preferences/devices/boseBuds/configureWindow.js';
 import * as EdifierBuds from '../preferences/devices/edifierBuds/configureWindow.js';
+import * as OneMoreBuds from '../preferences/devices/oneMoreBuds/configureWindow.js';
 import * as Gfps from '../preferences/devices/gfps/configureWindow.js';
 
 let _settings = null;
@@ -71,6 +72,10 @@ export function createConfigureWindow({
         case 'edifierBuds':
             Prefs = EdifierBuds;
             schemaKey = 'edifier-buds-list';
+            break;
+        case 'oneMoreBuds':
+            Prefs = OneMoreBuds;
+            schemaKey = 'one-more-buds-list';
             break;
         case 'gfps':
             Prefs = Gfps;

--- a/src/io.github.maniacx.BudsLink.src.gresource.xml
+++ b/src/io.github.maniacx.BudsLink.src.gresource.xml
@@ -200,6 +200,12 @@
         <file>lib/devices/edifierBuds/deviceConfigs/X5Pro.js</file>
         <file>preferences/devices/edifierBuds/configureWindow.js</file>
 
+        <file>lib/devices/oneMoreBuds/oneMoreBudsConfig.js</file>
+        <file>lib/devices/oneMoreBuds/oneMoreBudsDevice.js</file>
+        <file>lib/devices/oneMoreBuds/oneMoreBudsSocket.js</file>
+        <file>lib/devices/oneMoreBuds/deviceConfigs/SonoFlow.js</file>
+        <file>preferences/devices/oneMoreBuds/configureWindow.js</file>
+
         <file>lib/devices/sony/sonyConfig.js</file>
         <file>lib/devices/sony/sonyDevice.js</file>
         <file>lib/devices/sony/sonySocketBase.js</file>

--- a/src/lib/devices/oneMoreBuds/deviceConfigs/SonoFlow.js
+++ b/src/lib/devices/oneMoreBuds/deviceConfigs/SonoFlow.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/*
+ * 1MORE SonoFlow (HC905).
+ *
+ * An over-ear ANC headphone identified by its 1MORE model name / internal
+ * model code HC905. Controlled over a classic SPP (RFCOMM) link using the
+ * standard serial profile UUID, exactly like the official app.
+ */
+export default {
+    name: 'SonoFlow',
+    id: ['HC905', 'HQ33'],
+    type: 'headphones',
+
+    /* Detects this model among the audio devices paired with BlueZ. */
+    namePatterns: [
+        /.*1MORE\s+Sono[Ff]low.*/i,
+        /.*Sono[Ff]low\s+QC30.*/i,
+    ],
+
+    /* An over-ear headphone reports one battery; the 0x4E binaural-info frame
+       may carry redundant left/right/box fields, so present it as a single
+       level like the other over-ear models in BudsLink. */
+    batteryMultiple: false,
+    batteryCase: false,
+
+    /* Airoha listen-mode selector this model exposes:
+       0 off, 1 strong (ANC), 2 mild, 3 transparent. */
+    noiseControl: {
+        modes: ['off', 'nc', 'ambient'],
+    },
+
+    /* Sound-style preset selector (0x69/0x6A PRESET_SOUND). The 0x3B/0x3C
+       EQ-mode commands the earbuds use are not answered on this model. */
+    equalizer: true,
+    eqPresetModel: 'presetSound',
+
+    /* Double / triple click gesture configuration (0x64/0x66). The firmware
+       replies cmd 0x00 to both GETs — gestures are not supported on this
+       model, so the rows are hidden and no GETs are sent. */
+    gestures: false,
+
+    /* 0x5A find-my-device. The device replies cmd 0x02 to the 0x5A trigger
+       (a generic packet ACK) but answers cmd 0x00 to the 0x5B FindDeviceUI
+       capability query and never starts a beeper — the official app would
+       not offer find for this model, so the row stays hidden. */
+    findMyBuds: false,
+
+    albumArtIcon: 'headphone1',
+    budsIcon: 'headphone1',
+    case: 'case-normal',
+};

--- a/src/lib/devices/oneMoreBuds/oneMoreBudsConfig.js
+++ b/src/lib/devices/oneMoreBuds/oneMoreBudsConfig.js
@@ -1,0 +1,118 @@
+'use strict';
+
+import SonoFlow from './deviceConfigs/SonoFlow.js';
+
+export const OneMoreBudsModelList = [
+    SonoFlow,
+];
+
+/**
+Reference Material and Credits
+
+Protocol recovered from the "1MORE MUSIC" Android application
+(com.onemore.connect): com.onemore.music.module.ui.cmd.{CmdKt, DispatcherKt,
+ConstKt}, com.onemore.music.module.spp.{BluetoothOrderConstents,
+BluetoothService, BluetoothSPP}.
+**/
+
+/* SPP frame header offsets — built by CmdKt.makeData().
+   [flag][port][cmdHi][cmdLo][lenHi][lenLo][seqHi][seqLo][checksum][payload...] */
+export const FrameHeader = {
+    SPP_FLAG: 0x11,
+    SPP_PORT: 0x01,
+    /* BLE path uses makeReceiveBleData: flag 0x01, port 0x00 */
+    BLE_FLAG: 0x01,
+    BLE_PORT: 0x00,
+    HEADER_LEN: 9,
+};
+
+/* cmd byte pairs — BluetoothOrderConstents / CmdKt.
+   Each GET command uses cmdHi == cmdLo == the code. */
+export const CommandType = {
+    SHAKE_HAND: 0x4D,
+    BINAURAL_INFO: 0x4E,
+
+    EQ_PARAMS_SET: 0x53,
+    EQ_PARAMS_GET: 0x54,
+
+    /* Sound-style preset selector (over-ear models like SonoFlow). */
+    PRESET_SOUND_SET: 0x69,
+    PRESET_SOUND_GET: 0x6A,
+
+    FIND_DEVICE: 0x5A,
+
+    EQ_MODE_SET: 0x3B,
+    EQ_MODE_GET: 0x3C,
+
+    LISTEN_MODE_SET: 0x5E,
+    LISTEN_MODE_GET: 0x5F,
+
+    AUTO_PLAY_SET: 0x62,
+    AUTO_PLAY_GET: 0x63,
+
+    DOUBLE_CLICK_SET: 0x64,
+    DOUBLE_CLICK_GET: 0x65,
+
+    TRIPLE_CLICK_SET: 0x66,
+    TRIPLE_CLICK_GET: 0x67,
+};
+
+/* Listen-mode values — ConstKt.listenModeName(). */
+export const ListenMode = {
+    OFF: 0x00,
+    STRONG: 0x01,
+    MILD: 0x02,
+    TRANSPARENT: 0x03,
+    WNR: 0x04,
+    PASS_THROUGH: 0x05,
+    VOICE_ENHANCEMENT: 0x06,
+    ADAPTIVE: 0x07,
+};
+
+/* EQ preset selector — ConstKt.eqModeName(). */
+export const EqPreset = {
+    MUSIC: 0x00,
+    SLEEP: 0x01,
+};
+
+/* Sound-style presets for over-ear models (0x69/0x6A PRESET_SOUND). The
+   official app builds this exact list in TestKt#custSoundData() and the
+   sound-style picker is fed straight from it; HC905 is not among the models
+   given their own list, so these default names apply. */
+export const SonoFlowPreset = {
+    names: [
+        'Studio',             // 0x00
+        'Bass reducer',       // 0x01
+        'Bass booster',       // 0x02
+        'Acoustic',           // 0x03
+        'Classical',          // 0x04
+        'Podcast',            // 0x05
+        'Deep',               // 0x06
+        'Electronic',         // 0x07
+        'Hip-Hop',            // 0x08
+        'Lounge',             // 0x09
+        'Pop',                // 0x0A
+        'Voice Enhancement',  // 0x0B
+    ],
+    values: Array.from({length: 12}, (_, i) => i),
+};
+
+/* Double click / triple click actions. The earbuds (binaural) and over-ear
+   (monaural-connected) devices accept slightly different sets — over-ear
+   (monaural) list: 0 off, 1 next, 2 prev, 3 vol_down, 4 vol_up. */
+export const ClickAction = {
+    OFF: 0x00,
+    NEXT: 0x01,
+    PREV: 0x02,
+    VOL_DOWN: 0x03,
+    VOL_UP: 0x04,
+    PLAY_PAUSE: 0x05,
+    VOICE_CONTROL: 0x06,
+};
+
+/* FindDevice payload: [left][right], 0x01 = ring, 0x00 = stop. */
+export const FindDevice = {
+    LEFT_RING: [0x01, 0x00],
+    RIGHT_RING: [0x00, 0x01],
+    STOP: [0x00, 0x00],
+};

--- a/src/lib/devices/oneMoreBuds/oneMoreBudsDevice.js
+++ b/src/lib/devices/oneMoreBuds/oneMoreBudsDevice.js
@@ -1,0 +1,544 @@
+'use strict';
+import Gio from 'gi://Gio';
+import GObject from 'gi://GObject';
+import {gettext as _} from 'gettext';
+
+import {createLogger, getDeviceIdentifier, hexBytes} from '../logger.js';
+import {
+    validateProperties, launchConfigureWindow, SppUUidType, SppUUid
+} from '../deviceUtils.js';
+import {createConfig, createProperties, DataHandler} from '../../dataHandler.js';
+import {OneMoreBudsSocket} from './oneMoreBudsSocket.js';
+import {
+    OneMoreBudsModelList, ListenMode, EqPreset, ClickAction, SonoFlowPreset
+} from './oneMoreBudsConfig.js';
+
+export const DeviceTypeOneMoreBuds = 'oneMoreBuds';
+
+/* The standard SPP serial UUID is shared by many vendors; detection must key
+   off a 1MORE-specific suffix in the device alias so we do not claim Bose,
+   Sony or generic serial devices. */
+const OneMoreAliasPatterns = [
+    /1MORE\s+Sono[Ff]low/i,
+    /1MORE\s+S-31/i,
+    /1MORE\s+S70/i,
+    /1MORE\s+S51|ES603|EH603/i,
+    /1MORE\s+Comfo[Ff]uds/i,
+    /1MORE\s+Piston[Bb]uds/i,
+    /1MORE\s+S20|S21|S22|S23|S25|S52/i,
+    /1MORE\s+NANO/i,
+    /1MORE\s+HQ20|HQ36|HQ51|HQ52/i,
+    /1MORE\s+Z30/i,
+    /1MORE\s+Aero/i,
+    /1MORE\s+EVO|EH902/i,
+    /1MORE\s+Neo|EO007/i,
+];
+
+export function isOneMoreBuds(bluezDeviceProxy, uuids) {
+    const bluezProps = ['Alias'];
+    let supported = 'no';
+
+    if (!uuids.some(u => u.toLowerCase() === SppUUid))
+        return {supported, bluezProps};
+
+    let alias = bluezDeviceProxy.Alias;
+    if (!alias) {
+        supported = 'pending';
+        return {supported, bluezProps};
+    }
+
+    if (OneMoreAliasPatterns.some(p => p.test(alias)))
+        supported = 'yes';
+
+    return {supported, bluezProps};
+}
+
+export const OneMoreBudsDevice = GObject.registerClass({
+    GTypeName: 'BudsLink_OneMoreBudsDevice',
+}, class OneMoreBudsDevice extends GObject.Object {
+    _init(settings, devicePath, alias, extPath, profileManager, updateDeviceMapCb) {
+        super._init();
+
+        const identifier = getDeviceIdentifier(devicePath);
+        const tag = `OneMoreBudsDevice-${identifier}`;
+        this._log = createLogger(tag);
+        this._log.info('------------------- OneMoreBudsDevice init -------------------');
+        this._settings = settings;
+        this._devicePath = devicePath;
+        this._alias = alias;
+        this._extPath = extPath;
+        this.updateDeviceMapCb = updateDeviceMapCb;
+        this._ignoreGsettingsChange = false;
+
+        this._config = createConfig();
+        this._props = createProperties();
+        this._modelData = null;
+        this._fwVersion = '';
+
+        this._callbacks = {
+            updateHandshake: this.updateHandshake.bind(this),
+            updateBinauralInfo: this.updateBinauralInfo.bind(this),
+            updateNoiseControl: this.updateNoiseControl.bind(this),
+            updateEq: this.updateEq.bind(this),
+            updateDoubleClick: this.updateDoubleClick.bind(this),
+            updateTripleClick: this.updateTripleClick.bind(this),
+        };
+
+        this._modelData = OneMoreBudsModelList[0];
+
+        this._log.info(`Configuration: ${JSON.stringify(this._modelData, null, 2)}`);
+
+        this._commonIcon = this._modelData.budsIcon;
+        this._config.battery1ShowOnDisconnect = true;
+        this._config.showSettingsButton = true;
+
+        if (this._modelData.batteryCase)
+            this._caseIcon = `${this._modelData.case}`;
+        else
+            this._caseIcon = null;
+
+        this._createDefaultSettings();
+
+        const devicesList = this._settings.get_strv('one-more-buds-list').map(JSON.parse);
+
+        if (devicesList.length === 0 ||
+                !devicesList.some(device => device.path === this._devicePath)) {
+            this._addPropsToSettings(devicesList);
+        } else {
+            validateProperties(this._settings, 'one-more-buds-list', devicesList,
+                this._defaultsDeviceSettings, this._devicePath);
+        }
+
+        this._updateInitialValues();
+        this._monitorOneMoreBudsListGsettings();
+        this._updateIcons();
+        this._setupNoiseControlConfig();
+
+        const profile = {type: SppUUidType, uuid: SppUUid};
+
+        this._oneMoreBudsSocket = new OneMoreBudsSocket(
+            this._devicePath,
+            profileManager,
+            profile,
+            this._modelData,
+            this._callbacks
+        );
+    }
+
+    _createDefaultSettings() {
+        this._defaultsDeviceSettings = {
+            path: this._devicePath,
+            modelId: this._modelData.id[0],
+            alias: this._alias,
+            'nome-model-name': this._modelData.name,
+            icon: this._commonIcon,
+            'fw-version': this._fwVersion,
+
+            ...this._modelData.batteryCase && {
+                'case': this._caseIcon,
+            },
+
+            ...this._modelData.noiseControl && {
+                'listen-mode': 0,
+            },
+
+            ...this._modelData.equalizer && {
+                'eq-preset': EqPreset.MUSIC,
+            },
+
+            ...this._modelData.gestures && {
+                'double-click': ClickAction.OFF,
+                'triple-click': ClickAction.OFF,
+            },
+
+            ...this._modelData.findMyBuds && {
+                'ring-state': 'stopped',
+                'ring-state-left': 'stopped',
+            },
+        };
+    }
+
+    _addPropsToSettings(devicesList) {
+        devicesList.push(this._defaultsDeviceSettings);
+        this._settings.set_strv('one-more-buds-list', devicesList.map(JSON.stringify));
+    }
+
+    _updateInitialValues() {
+        const devicesList = this._settings.get_strv('one-more-buds-list').map(JSON.parse);
+        const existingPathIndex = devicesList.findIndex(
+            item => item.path === this._devicePath);
+        if (existingPathIndex === -1)
+            return;
+
+        this._settingsItems = devicesList[existingPathIndex];
+        this._commonIcon = this._settingsItems['icon'];
+
+        if (this._modelData.batteryCase)
+            this._caseIcon = this._settingsItems['case'];
+
+        if (this._modelData.noiseControl)
+            this._listenMode = this._settingsItems['listen-mode'];
+
+        if (this._modelData.equalizer)
+            this._eqPreset = this._settingsItems['eq-preset'];
+
+        if (this._modelData.gestures) {
+            this._doubleClick = this._settingsItems['double-click'];
+            this._tripleClick = this._settingsItems['triple-click'];
+        }
+
+        if (this._modelData.findMyBuds) {
+            this._ringState = 'stopped';
+            this._ringStateLeft = 'stopped';
+        }
+    }
+
+    _updateGsettingsProps() {
+        const devicesList = this._settings.get_strv('one-more-buds-list').map(JSON.parse);
+        const existingPathIndex = devicesList.findIndex(
+            item => item.path === this._devicePath);
+        if (existingPathIndex === -1)
+            return;
+
+        this._settingsItems = devicesList[existingPathIndex];
+
+        const icon = this._settingsItems['icon'];
+        if (this._commonIcon !== icon) {
+            this._commonIcon = icon;
+            this._updateIcons();
+        }
+
+        if (this._modelData.batteryCase) {
+            const caseIcon = this._settingsItems['case'];
+            if (this._caseIcon !== caseIcon) {
+                this._caseIcon = caseIcon;
+                this._updateIcons();
+            }
+        }
+
+        if (this._modelData.noiseControl) {
+            const listenMode = this._settingsItems['listen-mode'];
+            if (this._listenMode !== listenMode) {
+                this._listenMode = listenMode;
+                this._oneMoreBudsSocket?.setNoiseControl(listenMode);
+            }
+        }
+
+        if (this._modelData.equalizer) {
+            const eqPreset = this._settingsItems['eq-preset'];
+            if (this._eqPreset !== eqPreset) {
+                this._eqPreset = eqPreset;
+                this._oneMoreBudsSocket?.setEqPreset(eqPreset);
+            }
+        }
+
+        if (this._modelData.gestures) {
+            const doubleClick = this._settingsItems['double-click'];
+            if (this._doubleClick !== doubleClick) {
+                this._doubleClick = doubleClick;
+                this._oneMoreBudsSocket?.setDoubleClick(doubleClick);
+            }
+
+            const tripleClick = this._settingsItems['triple-click'];
+            if (this._tripleClick !== tripleClick) {
+                this._tripleClick = tripleClick;
+                this._oneMoreBudsSocket?.setTripleClick(tripleClick);
+            }
+        }
+
+        if (this._modelData.findMyBuds) {
+            const state = this._settingsItems['ring-state'];
+            if (this._ringState !== state) {
+                this._ringState = state;
+                this._setRingMyBuds(state);
+            }
+
+            const stateLeft = this._settingsItems['ring-state-left'];
+            if (this._ringStateLeft !== stateLeft) {
+                this._ringStateLeft = stateLeft;
+                this._setRingMyBuds(stateLeft, true);
+            }
+        }
+    }
+
+    _monitorOneMoreBudsListGsettings() {
+        this._settingsHandlerId = this._settings?.connect(
+            'changed::one-more-buds-list', () => {
+                if (this._ignoreGsettingsChange)
+                    return;
+
+                this._updateGsettingsProps();
+            });
+    }
+
+    _updateGsettings() {
+        this._ignoreGsettingsChange = true;
+
+        const currentList = this._settings.get_strv('one-more-buds-list').map(JSON.parse);
+        const index = currentList.findIndex(d => d.path === this._devicePath);
+
+        if (index !== -1) {
+            currentList[index] = this._settingsItems;
+            this._settings.set_strv('one-more-buds-list', currentList.map(JSON.stringify));
+        }
+
+        this._ignoreGsettingsChange = false;
+    }
+
+    _updateIcons() {
+        this._config.commonIcon = this._commonIcon;
+        this._config.albumArtIcon = this._commonIcon;
+
+        this._config.battery1ShowOnDisconnect = true;
+        this._config.battery1Icon = this._commonIcon;
+
+        this.dataHandler?.setConfig(this._config);
+    }
+
+    _setupNoiseControlConfig() {
+        const modes = this._modelData.noiseControl?.modes;
+        if (!modes || modes.length < 2)
+            return;
+
+        this._config.toggle1Title = _('Noise Control');
+        this._props.toggle1Visible = true;
+        this._toggle1Modes = modes;
+
+        const labels = {
+            off: _('Off'),
+            nc: _('Noise Cancellation'),
+            ambient: _('Ambient Sound'),
+        };
+
+        const icons = {
+            off: 'bbm-anc-off-symbolic.svg',
+            nc: 'bbm-anc-on-symbolic.svg',
+            ambient: 'bbm-transperancy-symbolic.svg',
+        };
+
+        for (let i = 1; i <= 4; i++) {
+            this._config[`toggle1Button${i}Name`] = '';
+            this._config[`toggle1Button${i}Icon`] = null;
+        }
+
+        modes.forEach((mode, index) => {
+            const button = index + 1;
+            this._config[`toggle1Button${button}Name`] = labels[mode] ?? mode;
+            this._config[`toggle1Button${button}Icon`] = icons[mode] ?? null;
+        });
+    }
+
+    _modeToListenValue(mode) {
+        switch (mode) {
+            case 'nc':
+                return ListenMode.STRONG;
+            case 'ambient':
+                return ListenMode.TRANSPARENT;
+            default:
+                return ListenMode.OFF;
+        }
+    }
+
+    _listenValueToMode(value) {
+        switch (value) {
+            case ListenMode.STRONG:
+                return 'nc';
+            case ListenMode.TRANSPARENT:
+                return 'ambient';
+            case ListenMode.OFF:
+                return 'off';
+            default:
+                return null;
+        }
+    }
+
+    _startConfiguration(battInfo) {
+        const bat1level = battInfo.battery1Level ?? 0;
+        const bat2level = battInfo.battery2Level ?? 0;
+        const bat3level = battInfo.battery3Level ?? 0;
+
+        if (bat1level <= 0 && bat2level <= 0 && bat3level <= 0)
+            return;
+
+        this._battInfoRecieved = true;
+
+        this.dataHandler = new DataHandler(this._config, this._props);
+
+        this.updateDeviceMapCb(this._devicePath, this.dataHandler);
+
+        this._dataHandlerId = this.dataHandler.connect(
+            'ui-action', (o, command, value) => {
+                if (command === 'toggle1State')
+                    this._toggle1ButtonClicked(value);
+
+                if (command === 'settingsButtonClicked')
+                    this._settingsButtonClicked();
+            }
+        );
+    }
+
+    /* The battery levels are reported by the 0x4E binaural-info reply rounded
+       to the nearest ten by the firmware. The left and right fields mirror the
+       same physical pack on over-ear models; prefer the highest sane value.
+       Firmware version is embedded as "x.y.z" in payload[1..3]. */
+    updateBinauralInfo(payload) {
+        if (payload.length < 10)
+            return;
+
+        const left = payload[4];
+        const right = payload[8];
+        const level = Math.max(left, right);
+
+        const status = val => val >= 1 && val <= 100
+            ? 'discharging' : 'disconnected';
+
+        this._battInfo = {
+            battery1Level: level,
+            battery1Status: status(level),
+        };
+
+        this.updateBatteryProps(this._battInfo);
+
+        const fwBytes = [payload[1], payload[2], payload[3]];
+        if (fwBytes.some(b => b > 0))
+            this.updateFirmware(fwBytes.join('.'));
+    }
+
+    /* The 0x4D reply carries a 16-byte license string. */
+    updateHandshake(payload) {
+        if (payload.length < 17)
+            return;
+
+        const bytes = payload.slice(1, 17);
+        const license = String.fromCharCode(...bytes).replace(/[^\x20-\x7E]/g, '');
+        this._log.info(`License: ${license}`);
+    }
+
+    updateBatteryProps(props) {
+        this._props = {...this._props, ...props};
+
+        if (!this._modelData)
+            return;
+
+        if (props.battery1Level >= 1 && props.battery1Level <= 100)
+            this._props.computedBatteryLevel = props.battery1Level;
+
+        this._log.info(`Battery INFO: ${JSON.stringify(props)}`);
+
+        if (!this._battInfoRecieved)
+            this._startConfiguration(props);
+
+        this.dataHandler?.setProps(this._props);
+    }
+
+    updateFirmware(fwVersion) {
+        this._fwVersion = fwVersion;
+        if (this._settingsItems) {
+            this._settingsItems['fw-version'] = fwVersion;
+            this._updateGsettings();
+        }
+    }
+
+    updateNoiseControl(value) {
+        this._log.info(`updateNoiseControl value: ${hexBytes(value)}`);
+
+        const mode = this._listenValueToMode(value);
+        if (!mode || !this._toggle1Modes)
+            return;
+
+        const index = this._toggle1Modes.indexOf(mode);
+        if (index === -1)
+            return;
+
+        this._listenMode = value;
+        this._props.toggle1State = index + 1;
+        this.dataHandler?.setProps(this._props);
+    }
+
+    updateEq(preset) {
+        this._log.info(`updateEq preset: ${hexBytes(preset)}`);
+        if (this._eqPreset !== preset) {
+            this._eqPreset = preset;
+            if (this._settingsItems) {
+                this._settingsItems['eq-preset'] = preset;
+                this._updateGsettings();
+            }
+        }
+    }
+
+    updateDoubleClick(action) {
+        this._log.info(`updateDoubleClick: ${hexBytes(action)}`);
+        if (this._doubleClick !== action) {
+            this._doubleClick = action;
+            if (this._settingsItems) {
+                this._settingsItems['double-click'] = action;
+                this._updateGsettings();
+            }
+        }
+    }
+
+    updateTripleClick(action) {
+        this._log.info(`updateTripleClick: ${hexBytes(action)}`);
+        if (this._tripleClick !== action) {
+            this._tripleClick = action;
+            if (this._settingsItems) {
+                this._settingsItems['triple-click'] = action;
+                this._updateGsettings();
+            }
+        }
+    }
+
+    /* FindDevice only supports ringing one earcup at a time; stop both when
+       either side stops. */
+    _setRingMyBuds(state, isLeft = false) {
+        const socket = this._oneMoreBudsSocket;
+        if (!socket || state === 'stopped') {
+            socket?.findStop();
+            return;
+        }
+
+        if (isLeft)
+            socket.findLeft();
+        else
+            socket.findRight();
+    }
+
+    _toggle1ButtonClicked(index) {
+        const mode = this._toggle1Modes?.[index - 1];
+        if (!mode)
+            return;
+
+        const value = this._modeToListenValue(mode);
+        this._props.toggle1State = index;
+        this._listenMode = value;
+        this.dataHandler?.setProps(this._props);
+        this._oneMoreBudsSocket?.setNoiseControl(value);
+    }
+
+    _settingsButtonClicked() {
+        this._configureWindowLauncherCancellable = new Gio.Cancellable();
+        launchConfigureWindow(this._devicePath, 'oneMoreBuds', this._extPath,
+            this._configureWindowLauncherCancellable);
+        this._configureWindowLauncherCancellable = null;
+    }
+
+    destroy() {
+        this._configureWindowLauncherCancellable?.cancel();
+        this._configureWindowLauncherCancellable = null;
+
+        this._oneMoreBudsSocket?.destroy();
+        this._oneMoreBudsSocket = null;
+
+        if (this._dataHandlerId)
+            this.dataHandler?.disconnect(this._dataHandlerId);
+        this._dataHandlerId = null;
+        this.dataHandler = null;
+
+        if (this._settingsHandlerId)
+            this._settings?.disconnect(this._settingsHandlerId);
+        this._settingsHandlerId = null;
+
+        this._settings = null;
+        this._battInfoRecieved = false;
+    }
+});

--- a/src/lib/devices/oneMoreBuds/oneMoreBudsSocket.js
+++ b/src/lib/devices/oneMoreBuds/oneMoreBudsSocket.js
@@ -1,0 +1,298 @@
+'use strict';
+import GObject from 'gi://GObject';
+import GLib from 'gi://GLib';
+
+import {createLogger, getDeviceIdentifier, hexBytes} from '../logger.js';
+import {SocketHandler} from '../socketByProfile.js';
+import {
+    CommandType, FrameHeader, FindDevice
+} from './oneMoreBudsConfig.js';
+
+export const OneMoreBudsSocket = GObject.registerClass({
+    GTypeName: 'BudsLink_OneMoreSocket',
+}, class OneMoreBudsSocket extends SocketHandler {
+    _init(devicePath, profileManager, profile, modelData, callbacks) {
+        super._init(devicePath, profileManager, profile);
+        const identifier = getDeviceIdentifier(devicePath);
+        this._log = createLogger(`OneMoreSocket-${identifier}`);
+        this._log.info('OneMoreSocket init');
+
+        this._callbacks = callbacks;
+        this._rxBuffer = [];
+        this._seq = 0;
+        this._modelData = modelData;
+        this._pendingInitResponse = null;
+
+        this.startSocket();
+    }
+
+    destroy() {
+        if (this._pendingInitResponse) {
+            if (this._pendingInitResponse.timeoutId)
+                GLib.source_remove(this._pendingInitResponse.timeoutId);
+            this._pendingInitResponse = null;
+        }
+        super.destroy();
+    }
+
+    async postConnectInitialization() {
+        /* The SonoFlow firmware processes one frame at a time: commands sent
+           in a burst before the previous reply arrives are dropped. Send each
+           command, waiting for its reply before moving on. */
+        await this._sendCommandAndWait(CommandType.SHAKE_HAND, [0x01]);
+        await this._sendCommandAndWait(CommandType.BINAURAL_INFO);
+
+        if (this._modelData?.noiseControl)
+            await this._sendCommandAndWait(CommandType.LISTEN_MODE_GET);
+
+        if (this._modelData?.equalizer)
+            await this._sendCommandAndWait(
+                this._getEqCommand(CommandType.EQ_MODE_GET));
+
+        if (this._modelData?.gestures) {
+            await this._sendCommandAndWait(CommandType.DOUBLE_CLICK_GET);
+            await this._sendCommandAndWait(CommandType.TRIPLE_CLICK_GET);
+        }
+    }
+
+    _sendCommandAndWait(command, payload = []) {
+        return new Promise(resolve => {
+            this._pendingInitResponse = {
+                resolve,
+                timeoutId: GLib.timeout_add(GLib.PRIORITY_DEFAULT, 2500, () => {
+                    this._pendingInitResponse = null;
+                    resolve();
+                    return GLib.SOURCE_REMOVE;
+                }),
+            };
+            this._sendCommand(command, payload);
+        });
+    }
+
+    /* --------------------------------------------------------------- framing */
+
+    /* Over-ear models expose the sound-style selector (0x69/0x6A); the
+       earbuds use the EQ-mode selector (0x3B/0x3C). */
+    _getEqCommand(setOrGet) {
+        return this._modelData?.eqPresetModel === 'presetSound'
+            ? setOrGet === CommandType.EQ_MODE_GET
+                ? CommandType.PRESET_SOUND_GET
+                : CommandType.PRESET_SOUND_SET
+            : setOrGet;
+    }
+
+    _nextSeq() {
+        this._seq = (this._seq + 1) & 0xFFFF;
+        return this._seq;
+    }
+
+    /* CmdKt.makeData: [flag][port][cmdHi][cmdLo][lenHi][lenLo][seqHi][seqLo]
+       checksum = XOR of the 8 header bytes. Multi-byte fields big-endian. */
+    _encode(command, payload = []) {
+        const cmdHi = command >> 8 & 0xFF;
+        const cmdLo = command & 0xFF;
+        const len = payload.length;
+        const seq = this._nextSeq();
+
+        const header = [
+            FrameHeader.SPP_FLAG,
+            FrameHeader.SPP_PORT,
+            cmdHi,
+            cmdLo,
+            len >> 8 & 0xFF,
+            len & 0xFF,
+            seq >> 8 & 0xFF,
+            seq & 0xFF,
+        ];
+
+        const checksum = header.reduce((acc, b) => acc ^ b, 0);
+
+        return [...header, checksum, ...payload];
+    }
+
+    _sendCommand(command, payload = [], loginfo = '') {
+        if (loginfo)
+            this._log.info(loginfo);
+
+        this.sendMessage(this._encode(command, payload));
+    }
+
+    /* --------------------------------------------------------------- decoding */
+
+    processData(data) {
+        this._rxBuffer.push(...data);
+
+        while (this._rxBuffer.length >= FrameHeader.HEADER_LEN) {
+            /* Discard leading garbage up to the SPP / BLE flag byte. */
+            const start = this._rxBuffer.findIndex(b =>
+                b === FrameHeader.SPP_FLAG || b === FrameHeader.BLE_FLAG);
+            if (start === -1) {
+                this._rxBuffer = [];
+                return;
+            }
+
+            if (start > 0)
+                this._rxBuffer.splice(0, start);
+
+            const frame = this._takeFrame();
+            if (!frame)
+                return;
+
+            this._handleFrame(frame);
+        }
+    }
+
+    /* Removes and returns one complete frame, or null once more bytes are
+       needed. The header length is big-endian and counts the payload only. */
+    _takeFrame() {
+        const buf = this._rxBuffer;
+        const flag = buf[0];
+        const port = buf[1];
+
+        const cmdHi = buf[2];
+        const cmdLo = buf[3];
+        const lenHi = buf[4];
+        const lenLo = buf[5];
+
+        const length = lenHi << 8 | lenLo;
+        const total = FrameHeader.HEADER_LEN + length;
+
+        if (buf.length < total)
+            return null;
+
+        const raw = buf.splice(0, total);
+        const header = raw.slice(0, 8);
+        const expected = header.reduce((acc, b) => acc ^ b, 0);
+
+        if (raw[8] !== expected) {
+            this._log.info(
+                `Checksum mismatch: expected ${hexBytes(expected)} ` +
+                `got ${hexBytes(raw[8])}`);
+            return null;
+        }
+
+        if (flag === FrameHeader.SPP_FLAG && port !== FrameHeader.SPP_PORT) {
+            this._log.info(`Unexpected SPP port ${hexBytes(port)}`);
+            return null;
+        }
+
+        return {
+            command: cmdHi << 8 | cmdLo,
+            payload: raw.slice(9),
+        };
+    }
+
+    _handleFrame({command, payload}) {
+        this._log.info(
+            `Received cmd ${hexBytes(command)} payload ${hexBytes(payload)}`);
+
+        if (this._pendingInitResponse) {
+            const pending = this._pendingInitResponse;
+            this._pendingInitResponse = null;
+            if (pending.timeoutId)
+                GLib.source_remove(pending.timeoutId);
+            pending.resolve();
+        }
+
+        switch (command) {
+            case CommandType.SHAKE_HAND:
+                this._callbacks.updateHandshake(payload);
+                break;
+
+            case CommandType.BINAURAL_INFO:
+                this._callbacks.updateBinauralInfo(payload);
+                break;
+
+            case CommandType.LISTEN_MODE_GET:
+            case CommandType.EQ_MODE_GET:
+            case CommandType.PRESET_SOUND_GET:
+            case CommandType.DOUBLE_CLICK_GET:
+            case CommandType.TRIPLE_CLICK_GET: {
+                if (payload.length < 1)
+                    break;
+                const value = payload[0];
+
+                if (command === CommandType.LISTEN_MODE_GET)
+                    this._callbacks.updateNoiseControl(value);
+                else if (command === CommandType.EQ_MODE_GET ||
+                        command === CommandType.PRESET_SOUND_GET)
+                    this._callbacks.updateEq(value);
+                else if (command === CommandType.DOUBLE_CLICK_GET)
+                    this._callbacks.updateDoubleClick(value);
+                else
+                    this._callbacks.updateTripleClick(value);
+                break;
+            }
+
+            /* SET replies carry only a result byte (0 failure, 1 success,
+               2 binaural pairing) — log it and move on. */
+            case CommandType.LISTEN_MODE_SET:
+            case CommandType.EQ_MODE_SET:
+            case CommandType.PRESET_SOUND_SET:
+            case CommandType.DOUBLE_CLICK_SET:
+            case CommandType.TRIPLE_CLICK_SET:
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    /* --------------------------------------------------------------- setters */
+
+    setNoiseControl(mode) {
+        this._sendCommand(CommandType.LISTEN_MODE_SET, [mode],
+            `Set listen mode: ${hexBytes(mode)}`);
+    }
+
+    setEqPreset(preset) {
+        this._sendCommand(this._getEqCommand(CommandType.EQ_MODE_SET), [preset],
+            `Set EQ preset: ${hexBytes(preset)}`);
+    }
+
+    setDoubleClick(action) {
+        this._sendCommand(CommandType.DOUBLE_CLICK_SET, [action],
+            `Set double click: ${hexBytes(action)}`);
+    }
+
+    setTripleClick(action) {
+        this._sendCommand(CommandType.TRIPLE_CLICK_SET, [action],
+            `Set triple click: ${hexBytes(action)}`);
+    }
+
+    /* The find-my-device command is exempt from the XOR checksum the rest of
+       the protocol uses: the SonoFlow firmware only honours the literal
+       checksum 0x78 that the official app always sends for cmd 0x5A
+       (BluetoothOrderConstents CMD_FindDevice frame). */
+    _sendFindCommand(payload, loginfo) {
+        if (loginfo)
+            this._log.info(loginfo);
+
+        const seq = this._nextSeq();
+
+        this.sendMessage(new Uint8Array([
+            FrameHeader.SPP_FLAG,
+            FrameHeader.SPP_PORT,
+            0x00,
+            CommandType.FIND_DEVICE,
+            0x00,
+            payload.length,
+            seq >> 8 & 0xFF,
+            seq & 0xFF,
+            0x78,
+            ...payload,
+        ]));
+    }
+
+    findLeft() {
+        this._sendFindCommand(FindDevice.LEFT_RING, 'Find left earcup');
+    }
+
+    findRight() {
+        this._sendFindCommand(FindDevice.RIGHT_RING, 'Find right earcup');
+    }
+
+    findStop() {
+        this._sendFindCommand(FindDevice.STOP, 'Stop find-my-device');
+    }
+});

--- a/src/lib/enhancedDeviceSupportManager.js
+++ b/src/lib/enhancedDeviceSupportManager.js
@@ -30,6 +30,9 @@ import {
 import {
     EdifierBudsDevice, isEdifierBuds, DeviceTypeEdifierBuds
 } from './devices/edifierBuds/edifierBudsDevice.js';
+import {
+    OneMoreBudsDevice, isOneMoreBuds, DeviceTypeOneMoreBuds
+} from './devices/oneMoreBuds/oneMoreBudsDevice.js';
 import {GfpsDevice, isGfps, DeviceTypeGfps} from './devices/gfps/gfpsDevice.js';
 
 export const EnhancedDeviceSupportManager = GObject.registerClass({
@@ -146,6 +149,11 @@ export const EnhancedDeviceSupportManager = GObject.registerClass({
                     enabled: this._toggle.edifierBudsEnabled,
                     check: isEdifierBuds,
                     type: DeviceTypeEdifierBuds,
+                },
+                {
+                    enabled: this._toggle.oneMoreBudsEnabled,
+                    check: isOneMoreBuds,
+                    type: DeviceTypeOneMoreBuds,
                 },
                 {
                     enabled: this._toggle.gfpsEnabled,
@@ -277,6 +285,11 @@ export const EnhancedDeviceSupportManager = GObject.registerClass({
                 } else if (deviceProps.type === DeviceTypeEdifierBuds) {
                     deviceProps.enhancedDevice =
                         new EdifierBudsDevice(this._settings, path, deviceProps.alias,
+                            this._extPath, this._profileManager,
+                            this.updateDeviceMapCb.bind(this));
+                } else if (deviceProps.type === DeviceTypeOneMoreBuds) {
+                    deviceProps.enhancedDevice =
+                        new OneMoreBudsDevice(this._settings, path, deviceProps.alias,
                             this._extPath, this._profileManager,
                             this.updateDeviceMapCb.bind(this));
                 } else if (deviceProps.type === DeviceTypeGfps) {

--- a/src/preferences/devices/oneMoreBuds/configureWindow.js
+++ b/src/preferences/devices/oneMoreBuds/configureWindow.js
@@ -1,0 +1,200 @@
+'use strict';
+import Adw from 'gi://Adw';
+import GObject from 'gi://GObject';
+
+import {
+    supportedAudioSingleIcons
+} from '../../../lib/widgets/iconGroups.js';
+import {DropDownRowWidget} from './../../widgets/dropDownRowWidget.js';
+import {IconSelectorWidget} from './../../widgets/iconSelectorWidget.js';
+import {RingMyBudsRow} from './../../widgets/ringMyBudsRow.js';
+import {
+    OneMoreBudsModelList, EqPreset, ClickAction, SonoFlowPreset
+} from '../../../lib/devices/oneMoreBuds/oneMoreBudsConfig.js';
+
+export const ConfigureWindow = GObject.registerClass({
+    GTypeName: 'BudsLink_OneMoreBudsConfigureWindow',
+}, class ConfigureWindow extends Adw.Window {
+    _init(settings, mac, devicePath, parentWindow, _, modal = false) {
+        super._init({
+            default_width: 650,
+            default_height: 650,
+            width_request: 320,
+            height_request: 100,
+            modal,
+            transient_for: parentWindow ?? null,
+        });
+
+        const clickOptions = [
+            _('Off'),
+            _('Next Track'),
+            _('Previous Track'),
+            _('Volume Down'),
+            _('Volume Up'),
+            _('Play / Pause'),
+            _('Voice Control'),
+        ];
+
+        const clickValues = [
+            ClickAction.OFF,
+            ClickAction.NEXT,
+            ClickAction.PREV,
+            ClickAction.VOL_DOWN,
+            ClickAction.VOL_UP,
+            ClickAction.PLAY_PAUSE,
+            ClickAction.VOICE_CONTROL,
+        ];
+
+        this._settings = settings;
+        this._devicePath = devicePath;
+
+        const pathsString = this._settings.get_strv('one-more-buds-list').map(JSON.parse);
+        this._settingsItems = pathsString.find(info => info.path === devicePath);
+        if (!this._settingsItems)
+            return;
+
+        this.title = this._settingsItems.alias;
+
+        const modelData = OneMoreBudsModelList.find(
+            cfg => cfg.id.includes(this._settingsItems['modelId'])
+        ) ?? OneMoreBudsModelList[0];
+
+        const toolViewBar = new Adw.ToolbarView();
+        const headerBar = new Adw.HeaderBar();
+        const page = new Adw.PreferencesPage();
+
+        toolViewBar.add_top_bar(headerBar);
+        toolViewBar.set_content(page);
+        this.set_content(toolViewBar);
+
+        const iconSelector = new IconSelectorWidget({
+            gtxt: _,
+            grpTitle: _('Icon'),
+            rowTitle: _('Select Icon'),
+            rowSubtitle: _('Select the icon used for the indicator and quick menu'),
+            iconList: supportedAudioSingleIcons,
+            initialIcon: this._settingsItems['icon'] || 'headphone1',
+            mac,
+            fw: this._settingsItems['fw-version'] || '',
+        });
+
+        iconSelector.connect('notify::selected-icon', () => {
+            this._updateGsettings('icon', iconSelector.selected_icon);
+        });
+
+        page.add(iconSelector);
+
+        const settingsGroup = new Adw.PreferencesGroup({title: _('Settings')});
+        page.add(settingsGroup);
+
+        if (modelData.equalizer) {
+            const isPresetSound = modelData.eqPresetModel === 'presetSound';
+
+            this._eqDropdown = new DropDownRowWidget({
+                title: _('Equalizer Preset'),
+                subtitle: _('Change the sound signature'),
+                options: isPresetSound ? SonoFlowPreset.names : [_('Music'), _('Sleep')],
+                values: isPresetSound ? SonoFlowPreset.values : [EqPreset.MUSIC, EqPreset.SLEEP],
+                initialValue: this._settingsItems['eq-preset'],
+            });
+
+            this._eqDropdown.connect('notify::selected-item', () => {
+                this._updateGsettings('eq-preset', this._eqDropdown.selected_item);
+            });
+
+            settingsGroup.add(this._eqDropdown);
+        }
+
+        if (modelData.gestures) {
+            this._doubleClickDropdown = new DropDownRowWidget({
+                title: _('Double Click'),
+                subtitle: _('Action performed on a double click'),
+                options: clickOptions,
+                values: clickValues,
+                initialValue: this._settingsItems['double-click'],
+            });
+
+            this._doubleClickDropdown.connect('notify::selected-item', () => {
+                this._updateGsettings('double-click', this._doubleClickDropdown.selected_item);
+            });
+
+            settingsGroup.add(this._doubleClickDropdown);
+
+            this._tripleClickDropdown = new DropDownRowWidget({
+                title: _('Triple Click'),
+                subtitle: _('Action performed on a triple click'),
+                options: clickOptions,
+                values: clickValues,
+                initialValue: this._settingsItems['triple-click'],
+            });
+
+            this._tripleClickDropdown.connect('notify::selected-item', () => {
+                this._updateGsettings('triple-click', this._tripleClickDropdown.selected_item);
+            });
+
+            settingsGroup.add(this._tripleClickDropdown);
+        }
+
+        if (modelData.findMyBuds) {
+            const miscGroup = new Adw.PreferencesGroup({title: _('Find My Earbuds')});
+            page.add(miscGroup);
+
+            this._ringBudsRow = new RingMyBudsRow(_, {dual: true});
+
+            this._ringBudsRow.connect('notify::status', () => {
+                this._updateGsettings('ring-state', this._ringBudsRow.status);
+            });
+
+            this._ringBudsRow.connect('notify::status-left', () => {
+                this._updateGsettings('ring-state-left', this._ringBudsRow.statusLeft);
+            });
+
+            miscGroup.add(this._ringBudsRow);
+        }
+
+        const settingSignalId = this._settings.connect('changed::one-more-buds-list', () => {
+            const updatedList =
+                this._settings.get_strv('one-more-buds-list').map(JSON.parse);
+            this._settingsItems = updatedList.find(info => info.path === devicePath);
+            if (!this._settingsItems)
+                return;
+
+            this.title = this._settingsItems.alias;
+
+            if (this._eqDropdown)
+                this._eqDropdown.selected_item = this._settingsItems['eq-preset'];
+
+            if (this._doubleClickDropdown)
+                this._doubleClickDropdown.selected_item = this._settingsItems['double-click'];
+
+            if (this._tripleClickDropdown)
+                this._tripleClickDropdown.selected_item = this._settingsItems['triple-click'];
+
+            if (this._ringBudsRow) {
+                this._ringBudsRow.status = this._settingsItems['ring-state'];
+                this._ringBudsRow.statusLeft = this._settingsItems['ring-state-left'];
+            }
+        });
+
+        this.connect('close-request', () => {
+            if (settingSignalId && this._settings)
+                this._settings.disconnect(settingSignalId);
+
+            this._settings = null;
+
+            return false;
+        });
+    }
+
+    _updateGsettings(key, value) {
+        const pairedDevice = this._settings.get_strv('one-more-buds-list');
+        const existingPathIndex =
+                pairedDevice.findIndex(item => JSON.parse(item).path === this._devicePath);
+        if (existingPathIndex !== -1) {
+            const existingItem = JSON.parse(pairedDevice[existingPathIndex]);
+            existingItem[key] = value;
+            pairedDevice[existingPathIndex] = JSON.stringify(existingItem);
+            this._settings.set_strv('one-more-buds-list', pairedDevice);
+        }
+    }
+});


### PR DESCRIPTION
Add device support for 1MORE SonoFlow (HC905 / HQ33) over-ear ANC
headphones, communicating over Bluetooth Serial Port Profile (RFCOMM).

Protocol details recovered from the 1MORE MUSIC Android app
(com.onemore.connect): SPP framing (0x11 flag, XOR checksum,
seq counters), command pairs 0x4D/0x4E handshake + binaural info,
0x5E/0x5F noise control (off / NC / ambient), 0x69/0x6A sound-style
preset selector (12 presets: Studio … Voice Enhancement), 0x5A.